### PR TITLE
run etcd in same pod as apiserver

### DIFF
--- a/charts/konk/templates/deployment.yaml
+++ b/charts/konk/templates/deployment.yaml
@@ -28,29 +28,59 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: apiserver
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- toYaml .Values.apiserver.securityContext | nindent 12 }}
+          image: "{{ .Values.apiserver.image.repository }}:{{ .Values.apiserver.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.apiserver.image.pullPolicy }}
           command:
             - /usr/local/bin/kube-apiserver
           args:
             - --etcd-cafile=/etc/kubernetes/pki/apiserver/etcd/ca.pem
             - --etcd-certfile=/etc/kubernetes/pki/apiserver/etcd/cert.pem
             - --etcd-keyfile=/etc/kubernetes/pki/apiserver/etcd/key.pem
-            - --etcd-servers=https://127.0.0.1:4001 # TODO: provision etcd
+            - --etcd-servers=https://127.0.0.1:2379
             # TODO: mount certs
           ports:
             - name: https
               containerPort: 443
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: https
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.apiserver.resources | nindent 12 }}
+          volumeMounts:
+          - mountPath: /etc/kubernetes/pki/apiserver/etcd
+            name: etcd-client-certs
+            readOnly: true
+        - name: etcd
+          securityContext:
+            {{- toYaml .Values.etcd.securityContext | nindent 12 }}
+          image: "{{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
+          command:
+            - etcd
+            - --advertise-client-urls=https://127.0.0.1:2379
+            - --cert-file=/var/lib/minikube/certs/etcd/server.crt
+            - --client-cert-auth=true
+            - --data-dir=/var/lib/minikube/etcd
+            - --key-file=/var/lib/minikube/certs/etcd/server.key
+            - --listen-client-urls=https://127.0.0.1:2379
+            - --listen-metrics-urls=http://127.0.0.1:2381
+            - --name=minikube
+            - --snapshot-count=10000
+            - --trusted-ca-file=/var/lib/minikube/certs/etcd/ca.crt
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              host: 127.0.0.1
+              path: /health
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+          resources:
+            {{- toYaml .Values.etcd.resources | nindent 12 }}
           volumeMounts:
           - mountPath: /etc/kubernetes/pki/apiserver/etcd
             name: etcd-client-certs

--- a/charts/konk/templates/deployment.yaml
+++ b/charts/konk/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           command:
             - /usr/local/bin/kube-apiserver
           args:
+            - --etcd-cafile=/etc/kubernetes/pki/apiserver/etcd/ca.pem
+            - --etcd-certfile=/etc/kubernetes/pki/apiserver/etcd/cert.pem
+            - --etcd-keyfile=/etc/kubernetes/pki/apiserver/etcd/key.pem
             - --etcd-servers=https://127.0.0.1:4001 # TODO: provision etcd
             # TODO: mount certs
           ports:
@@ -48,6 +51,15 @@ spec:
               port: https
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - mountPath: /etc/kubernetes/pki/apiserver/etcd
+            name: etcd-client-certs
+            readOnly: true
+      volumes:
+      - name: etcd-client-certs
+        secret:
+          defaultMode: 256
+          secretName: {{ include "konk.fullname" . }}-etcd-cert
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/konk/templates/etcd-secret.yaml
+++ b/charts/konk/templates/etcd-secret.yaml
@@ -1,0 +1,14 @@
+{{- /* TODO: replace with kubeadm certs */ -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "konk.fullname" . }}-etcd-cert
+  labels:
+    {{- include "konk.labels" . | nindent 4 }}
+data:
+{{- $ca := genCA "konk-ca" 365 }}
+{{- $cert := genSignedCert "root" ( list "127.0.0.1" ) ( list ( printf "%s-%s" .Release.Name "etcd-headless") ) 365 $ca }}
+  ca.pem: {{ $ca.Cert | b64enc }}
+  cert.pem: {{ $cert.Cert | b64enc }}
+  key.pem: {{ $cert.Key | b64enc }}

--- a/charts/konk/values.yaml
+++ b/charts/konk/values.yaml
@@ -4,11 +4,55 @@
 
 replicaCount: 1
 
-image:
-  repository: k8s.gcr.io/kube-apiserver
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+apiserver:
+  image:
+    repository: k8s.gcr.io/kube-apiserver
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+etcd:
+  image:
+    repository: k8s.gcr.io/etcd
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "3.4.9-1" # keep image versions in sync with `kubeadm config images list`
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
 imagePullSecrets: []
 nameOverride: ""
@@ -28,14 +72,6 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
 service:
   type: ClusterIP
   port: 443
@@ -53,18 +89,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
demo:
```
% k get po                                                                                                                   minikube
NAME                           READY   STATUS    RESTARTS   AGE
thayward-konk-cdc746cf-vbgvr   2/2     Running   0          76s
```
```
% k logs thayward-konk-cdc746cf-vbgvr apiserver --tail 10                                                                    minikube
I0828 23:06:09.506820       1 storage_scheduling.go:143] all system priority classes are created successfully or already exist.
W0828 23:06:09.549314       1 lease.go:233] Resetting endpoints for master service "kubernetes" to [172.18.0.4]
I0828 23:06:09.550618       1 controller.go:606] quota admission added evaluator for: endpoints
I0828 23:06:09.556961       1 controller.go:606] quota admission added evaluator for: endpointslices.discovery.k8s.io
I0828 23:06:39.897245       1 client.go:360] parsed scheme: "passthrough"
I0828 23:06:39.897410       1 passthrough.go:48] ccResolverWrapper: sending update to cc: {[{https://127.0.0.1:2379  <nil> 0 <nil>}] <nil> <nil>}
I0828 23:06:39.897431       1 clientconn.go:948] ClientConn switching balancer to "pick_first"
I0828 23:07:18.413272       1 client.go:360] parsed scheme: "passthrough"
I0828 23:07:18.413326       1 passthrough.go:48] ccResolverWrapper: sending update to cc: {[{https://127.0.0.1:2379  <nil> 0 <nil>}] <nil> <nil>}
I0828 23:07:18.413362       1 clientconn.go:948] ClientConn switching balancer to "pick_first"
```