### PR TITLE
add make target to generate images tag values synced to a k8s release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 CHART_DIR	:= charts
 HELM		?= helm # point to helm 3
+K8S_RELEASE	?= v1.19.0
+KUBEADM		?= docker run --rm -it --entrypoint="" kindest/node:$(K8S_RELEASE) kubeadm
 RELEASE_NAME	?= $(USER)
+
+.PHONY: charts/konk/image-tag-values.yaml
+charts/konk/image-tag-values.yaml:
+	@IMAGES=`$(KUBEADM) config images list` && \
+	APISERVER_VERSION=`echo "$$IMAGES" | grep apiserver | cut -d: -f2` && \
+	ETCD_VERSION=`echo "$$IMAGES" | grep etcd | cut -d: -f2` && \
+	echo "# kubernetes $(K8S_RELEASE)\napiserver:\n  image:\n    tag: $$APISERVER_VERSION\netcd:\n  image:\n    tag: $$ETCD_VERSION" | tee $@
 
 deploy-%:
 	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+CHART_DIR	:= charts
+HELM		?= helm # point to helm 3
+RELEASE_NAME	?= $(USER)
+
+deploy-%:
+	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$*
+
+teardown-%:
+	$(HELM) delete $(RELEASE_NAME)-$*

--- a/charts/konk/image-tag-values.yaml
+++ b/charts/konk/image-tag-values.yaml
@@ -1,0 +1,7 @@
+# kubernetes v1.19.0
+apiserver:
+  image:
+    tag: v1.19.0
+etcd:
+  image:
+    tag: 3.4.9-1


### PR DESCRIPTION
To simplify deploying with compatible image versions for any release of k8s, a make target to generate the overrides is provided.

Demo:
```
% make charts/konk/image-tag-values.yaml
# kubernetes v1.19.0
apiserver:
  image:
    tag: v1.19.0
etcd:
  image:
    tag: 3.4.9-1
```
```
% make charts/konk/image-tag-values.yaml K8S_RELEASE=v1.15.7
# kubernetes v1.15.7
apiserver:
  image:
    tag: v1.15.12
etcd:
  image:
    tag: 3.3.10
```