### PR TITLE
support --wait during install

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,4 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
         run: |
           kubectl cluster-info
-          make deploy-konk
-          kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/instance=$USER-konk
-          make test-konk
+          make deploy-konk test-konk

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ helm-lint-%:
 	$(HELM) lint $(CHART_DIR)/$*
 
 deploy-%:
-	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$*
+	$(HELM) upgrade -i --wait $(RELEASE_NAME)-$* $(CHART_DIR)/$*
 
 test-%:
 	$(HELM) test $(RELEASE_NAME)-$* \

--- a/charts/konk/scripts/provision.sh
+++ b/charts/konk/scripts/provision.sh
@@ -22,3 +22,5 @@ then
   kubectl -n {{ .Release.Namespace }} create secret generic {{ include "konk.fullname" . }}-kubeconfig \
     --from-file=/etc/kubernetes/admin.conf
 fi
+
+sleep 300

--- a/charts/konk/scripts/provision.sh
+++ b/charts/konk/scripts/provision.sh
@@ -23,4 +23,7 @@ then
     --from-file=/etc/kubernetes/admin.conf
 fi
 
+echo
+date
+echo done.
 sleep 300

--- a/charts/konk/templates/init-pod.yaml
+++ b/charts/konk/templates/init-pod.yaml
@@ -29,3 +29,4 @@ spec:
       name: {{ include "konk.fullname" . }}-scripts
       defaultMode: 0777
   restartPolicy: OnFailure
+  terminationGracePeriodSeconds: 10


### PR DESCRIPTION
https://github.com/infobloxopen/konk/pull/11#discussion_r483896814 requested adding `--wait`. Since helm does not consider Completed pods ready, we can support `--wait` by making the init script hang instead of completing.