### PR TITLE
use environment variables to eliminate requirement of templating inside scripts

### DIFF
--- a/charts/konk/scripts/provision.sh
+++ b/charts/konk/scripts/provision.sh
@@ -2,23 +2,23 @@
 
 kubeadm init phase certs all
 kubeadm init phase kubeconfig admin
-if ! kubectl -n {{ .Release.Namespace }} get secret {{ include "konk.fullname" . }}-etcd-cert
+if ! kubectl -n $NAMESPACE get secret $FULLNAME-etcd-cert
 then
-  kubectl -n {{ .Release.Namespace }} create secret generic {{ include "konk.fullname" . }}-etcd-cert \
+  kubectl -n $NAMESPACE create secret generic $FULLNAME-etcd-cert \
     --from-file=/etc/kubernetes/pki/etcd/ca.crt \
     --from-file=/etc/kubernetes/pki/etcd/server.crt \
     --from-file=/etc/kubernetes/pki/etcd/server.key
 fi
-if ! kubectl -n {{ .Release.Namespace }} get secret {{ include "konk.fullname" . }}-apiserver-cert
+if ! kubectl -n $NAMESPACE get secret $FULLNAME-apiserver-cert
 then
-  kubectl -n {{ .Release.Namespace }} create secret generic {{ include "konk.fullname" . }}-apiserver-cert \
+  kubectl -n $NAMESPACE create secret generic $FULLNAME-apiserver-cert \
     --from-file=/etc/kubernetes/pki/ca.crt \
     --from-file=etcd-ca.crt=/etc/kubernetes/pki/etcd/ca.crt \
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.crt \
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.key
 fi
-if ! kubectl -n {{ .Release.Namespace }} get secret {{ include "konk.fullname" . }}-kubeconfig
+if ! kubectl -n $NAMESPACE get secret $FULLNAME-kubeconfig
 then
-  kubectl -n {{ .Release.Namespace }} create secret generic {{ include "konk.fullname" . }}-kubeconfig \
+  kubectl -n $NAMESPACE create secret generic $FULLNAME-kubeconfig \
     --from-file=/etc/kubernetes/admin.conf
 fi

--- a/charts/konk/templates/configmap.yaml
+++ b/charts/konk/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 data:
-{{ tpl (.Files.Glob "scripts/provision.sh").AsConfig . | indent 2 }}
+{{ (.Files.Glob "scripts/provision.sh").AsConfig | indent 2 }}

--- a/charts/konk/templates/init-pod.yaml
+++ b/charts/konk/templates/init-pod.yaml
@@ -17,6 +17,13 @@ spec:
       - bash
     args:
       - /scripts/provision.sh
+    env:
+      - name: NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: FULLNAME
+        value: {{ include "konk.fullname" . }}
     resources:
       {{- toYaml .Values.kind.resources | nindent 6 }}
     volumeMounts:


### PR DESCRIPTION
This allows using the script without the helm chart, such as during local development.