### PR TITLE
label secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,5 @@ test-%:
 
 teardown-%:
 	$(HELM) delete $(RELEASE_NAME)-$*
+	# TODO: add support for k8s or helm to clean up these secrets
+	kubectl delete secrets -l app.kubernetes.io/instance=$(RELEASE_NAME)-$*

--- a/charts/konk/scripts/provision.sh
+++ b/charts/konk/scripts/provision.sh
@@ -8,6 +8,7 @@ then
     --from-file=/etc/kubernetes/pki/etcd/ca.crt \
     --from-file=/etc/kubernetes/pki/etcd/server.crt \
     --from-file=/etc/kubernetes/pki/etcd/server.key
+  kubectl -n $NAMESPACE label secret $FULLNAME-etcd-cert $LABELS
 fi
 if ! kubectl -n $NAMESPACE get secret $FULLNAME-apiserver-cert
 then
@@ -16,9 +17,11 @@ then
     --from-file=etcd-ca.crt=/etc/kubernetes/pki/etcd/ca.crt \
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.crt \
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.key
+  kubectl -n $NAMESPACE label secret $FULLNAME-apiserver-cert $LABELS
 fi
 if ! kubectl -n $NAMESPACE get secret $FULLNAME-kubeconfig
 then
   kubectl -n $NAMESPACE create secret generic $FULLNAME-kubeconfig \
     --from-file=/etc/kubernetes/admin.conf
+  kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi

--- a/charts/konk/templates/init-pod.yaml
+++ b/charts/konk/templates/init-pod.yaml
@@ -24,6 +24,10 @@ spec:
             fieldPath: metadata.namespace
       - name: FULLNAME
         value: {{ include "konk.fullname" . }}
+      - name: LABELS
+        value: {{ (include "konk.selectorLabels" .) | replace ": " "=" | replace "\n" " " }}
+      - name: RELEASE
+        value: {{ .Release.Name }}
     resources:
       {{- toYaml .Values.kind.resources | nindent 6 }}
     volumeMounts:

--- a/charts/konk/templates/role.yaml
+++ b/charts/konk/templates/role.yaml
@@ -15,4 +15,5 @@ rules:
     - get
     - delete
     - list
+    - patch
     - watch


### PR DESCRIPTION
Labels the secrets created by the init pod so that we know which release they belong to.

Demo:
```
% k get secrets --show-labels                                                                                                minikube
NAME                                  TYPE                                  DATA   AGE   LABELS
default-token-4cvd9                   kubernetes.io/service-account-token   3      12d   <none>
sh.helm.release.v1.thayward-konk.v1   helm.sh/release.v1                    1      11s   modifiedAt=1599602297,name=thayward-konk,owner=helm,status=deployed,version=1
thayward-konk-apiserver-cert          Opaque                                4      7s    app.kubernetes.io/instance=thayward-konk,app.kubernetes.io/name=konk
thayward-konk-etcd-cert               Opaque                                3      7s    app.kubernetes.io/instance=thayward-konk,app.kubernetes.io/name=konk
thayward-konk-kubeconfig              Opaque                                1      7s    app.kubernetes.io/instance=thayward-konk,app.kubernetes.io/name=konk
thayward-konk-token-ljvjk             kubernetes.io/service-account-token   3      11s   <none>
```