### PR TITLE
disable unsupported APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ deploy-%:
 	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$*
 
 test-%:
-	$(HELM) test $(RELEASE_NAME)-$* \
-	|| { kubectl logs $(RELEASE_NAME)-$*-test-connection; exit 1; }
+	$(HELM) test --logs $(RELEASE_NAME)-$*
 
 teardown-%:
 	$(HELM) delete $(RELEASE_NAME)-$*

--- a/charts/konk/templates/deployment.yaml
+++ b/charts/konk/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             - --etcd-certfile=/etc/kubernetes/pki/apiserver/apiserver-etcd-client.crt
             - --etcd-keyfile=/etc/kubernetes/pki/apiserver/apiserver-etcd-client.key
             - --etcd-servers=https://127.0.0.1:2379
+            {{- range $api := .Values.apiserver.disabledAPIs }}
+            - --runtime-config={{ $api }}=false
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/konk/templates/tests/test-connection.yaml
+++ b/charts/konk/templates/tests/test-connection.yaml
@@ -17,7 +17,7 @@ spec:
       - --server=https://{{ include "konk.fullname" . }}:{{ .Values.service.port }}
       - --insecure-skip-tls-verify=true
       - get
-      - ns
+      - apiservices
     env:
       - name: KUBECONFIG
         value: /kubeconfig/admin.conf

--- a/charts/konk/values.yaml
+++ b/charts/konk/values.yaml
@@ -29,6 +29,18 @@ apiserver:
     # runAsNonRoot: true
     # runAsUser: 1000
   startupProbe: true
+  disabledAPIs:
+    - apps/v1
+    - apps/v1beta1
+    - autoscaling/v1
+    - autoscaling/v2beta1
+    - autoscaling/v2beta2
+    - batch/v1
+    - batch/v1beta1
+    - networking.k8s.io/v1
+    - networking.k8s.io/v1beta1
+    - storage.k8s.io/v1
+    - storage.k8s.io/v1beta1
 
 etcd:
   image:


### PR DESCRIPTION
KONK runs an apiserver independently without a node and CNI, so many features of Kubernetes like Deployments are unsupported. This PR disables them so that users will get an error when trying to create these types of resources.