### PR TITLE
generate certs and kubeconfig with correct service name

### DIFF
--- a/charts/konk/scripts/provision.sh
+++ b/charts/konk/scripts/provision.sh
@@ -1,7 +1,9 @@
-#!/bin/bash -xe
+#!/bin/bash
+set -xe
 
-kubeadm init phase certs all
-kubeadm init phase kubeconfig admin
+kubeadm init phase certs all --apiserver-cert-extra-sans $FULLNAME,$FULLNAME.$NAMESPACE,$FULLNAME.$NAMESPACE.svc
+kubeadm init phase kubeconfig admin --control-plane-endpoint $FULLNAME
+find /etc/kubernetes/pki
 if ! kubectl -n $NAMESPACE get secret $FULLNAME-etcd-cert
 then
   kubectl -n $NAMESPACE create secret generic $FULLNAME-etcd-cert \
@@ -13,6 +15,8 @@ fi
 if ! kubectl -n $NAMESPACE get secret $FULLNAME-apiserver-cert
 then
   kubectl -n $NAMESPACE create secret generic $FULLNAME-apiserver-cert \
+    --from-file=/etc/kubernetes/pki/apiserver.crt \
+    --from-file=/etc/kubernetes/pki/apiserver.key \
     --from-file=/etc/kubernetes/pki/ca.crt \
     --from-file=etcd-ca.crt=/etc/kubernetes/pki/etcd/ca.crt \
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.crt \

--- a/charts/konk/templates/deployment.yaml
+++ b/charts/konk/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
             {{- range $api := .Values.apiserver.disabledAPIs }}
             - --runtime-config={{ $api }}=false
             {{- end }}
+            - --tls-cert-file=/etc/kubernetes/pki/apiserver/apiserver.crt
+            - --tls-private-key-file=/etc/kubernetes/pki/apiserver/apiserver.key
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/konk/templates/tests/test-connection.yaml
+++ b/charts/konk/templates/tests/test-connection.yaml
@@ -14,8 +14,6 @@ spec:
     command:
       - kubectl
     args:
-      - --server=https://{{ include "konk.fullname" . }}:{{ .Values.service.port }}
-      - --insecure-skip-tls-verify=true
       - get
       - apiservices
     env:

--- a/charts/konk/values.yaml
+++ b/charts/konk/values.yaml
@@ -111,7 +111,7 @@ podSecurityContext: {}
 
 service:
   type: ClusterIP
-  port: 443
+  port: 6443
 
 ingress:
   enabled: false


### PR DESCRIPTION
The kubeconfig now trusts the apiserver.

Resolves TODO: https://github.com/infobloxopen/konk/pull/11#discussion_r483897211