### PR TITLE
Added ownerReferences to secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ test-%:
 
 teardown-%:
 	$(HELM) delete $(RELEASE_NAME)-$*
-	# TODO: add support for k8s or helm to clean up these secrets
-	kubectl delete secrets -l app.kubernetes.io/instance=$(RELEASE_NAME)-$*
 
 
 # Current Operator version

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -29,3 +29,10 @@ then
     --from-file=/etc/kubernetes/admin.conf
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi
+
+sleep 1m
+
+DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o yaml | grep uid | cut -c 8-)
+kubectl patch -n $NAMESPACE secret $FULLNAME-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+kubectl patch -n $NAMESPACE secret $FULLNAME-etcd-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+kubectl patch -n $NAMESPACE secret $FULLNAME-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -30,9 +30,9 @@ then
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi
 
-sleep 1m
+kubectl -n $NAMESPACE wait --timeout=3m --for=condition=available deployment -l app.kubernetes.io/instance=$FULLNAME
 
 DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o yaml | grep uid | cut -c 8-)
-kubectl patch -n $NAMESPACE secret $FULLNAME-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
-kubectl patch -n $NAMESPACE secret $FULLNAME-etcd-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
-kubectl patch -n $NAMESPACE secret $FULLNAME-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+kubectl patch -n $NAMESPACE secret $FULLNAME-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+kubectl patch -n $NAMESPACE secret $FULLNAME-etcd-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+kubectl patch -n $NAMESPACE secret $FULLNAME-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'

--- a/helm-charts/konk/templates/role.yaml
+++ b/helm-charts/konk/templates/role.yaml
@@ -8,8 +8,10 @@ metadata:
 rules:
   - apiGroups:
     - ""
+    - apps
     resources:
     - secrets
+    - deployments
     verbs:
     - create
     - get


### PR DESCRIPTION
Summary of changes - Updated the provision.sh script to add owner references to the secrets linking them to the konk deployment.

DEMO - 

```
sc-ml-avenkata:konk abalavenkata$ make deploy-konk
helm -n ab upgrade -i abalavenkata-konk helm-charts/konk
Release "abalavenkata-konk" does not exist. Installing it now.
NAME: abalavenkata-konk
LAST DEPLOYED: Thu Sep 10 14:47:04 2020
NAMESPACE: ab
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace ab -l "app.kubernetes.io/name=konk,app.kubernetes.io/instance=abalavenkata-konk" -o jsonpath="{.items[0].metadata.name}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace ab port-forward $POD_NAME 8080:80

sc-ml-avenkata:konk abalavenkata$ kubectl get secret -n ab abalavenkata-konk-apiserver-cert -oyaml
kind: Secret
metadata:
  creationTimestamp: "2020-09-10T21:47:09Z"
  labels:
    app.kubernetes.io/instance: abalavenkata-konk
    app.kubernetes.io/name: konk
  name: abalavenkata-konk-apiserver-cert
  namespace: ab
  ownerReferences:
  - apiVersion: v1
    kind: Deployment
    name: abalavenkata-konk
    uid: a2be0187-e6a2-48ce-8e87-00798e99aa54
  resourceVersion: "1767589"
  selfLink: /api/v1/namespaces/ab/secrets/abalavenkata-konk-apiserver-cert
  uid: f4031b6a-2be2-465e-869c-a7735db01f55
type: Opaque

sc-ml-avenkata:konk abalavenkata$ make teardown-konk
helm -n ab delete abalavenkata-konk
release "abalavenkata-konk" uninstalled

sc-ml-avenkata:konk abalavenkata$ kubectl get secret -n ab
NAME                  TYPE                                  DATA   AGE
default-token-mdz57   kubernetes.io/service-account-token   3      6d22h
```