### PR TITLE
fix owner uid

### DIFF
--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -32,7 +32,7 @@ fi
 
 kubectl -n $NAMESPACE wait --timeout=3m --for=condition=available deployment -l app.kubernetes.io/instance=$FULLNAME
 
-DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o yaml | grep uid | cut -c 8-)
+DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
 kubectl patch -n $NAMESPACE secret $FULLNAME-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 kubectl patch -n $NAMESPACE secret $FULLNAME-etcd-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 kubectl patch -n $NAMESPACE secret $FULLNAME-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -33,6 +33,7 @@ fi
 kubectl -n $NAMESPACE wait --timeout=3m --for=condition=available deployment -l app.kubernetes.io/instance=$FULLNAME
 
 DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
-kubectl patch -n $NAMESPACE secret $FULLNAME-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
-kubectl patch -n $NAMESPACE secret $FULLNAME-etcd-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
-kubectl patch -n $NAMESPACE secret $FULLNAME-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+for name in apiserver-cert etcd-cert kubeconfig
+do
+  kubectl patch -n $NAMESPACE secret $FULLNAME-$name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+done

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -30,7 +30,7 @@ then
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi
 
-kubectl -n $NAMESPACE wait --timeout=3m --for=condition=available deployment -l app.kubernetes.io/instance=$FULLNAME
+kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployment -l app.kubernetes.io/instance=$FULLNAME
 
 DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
 for name in apiserver-cert etcd-cert kubeconfig


### PR DESCRIPTION
I was seeing errors like this:
```
+ kubectl patch -n default secret test-konk-apiserver-cert -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"test-konk", "uid":"' 'k:{"uid":"1b2afbf1-f5b7-48dd-aee1-fa8d1831423c"}:' f:uid: '{}' : 1b2afbf1-f5b7-48dd-aee1-fa8d1831423c '9364ff59-6372-416c-9666-665698a9828e"}]}}'
Error from server (BadRequest): unexpected EOF
Error from server (NotFound): secrets "k:{\"uid\":\"1b2afbf1-f5b7-48dd-aee1-fa8d1831423c\"}:" not found
Error from server (NotFound): secrets "f:uid:" not found
Error from server (NotFound): secrets "{}" not found
Error from server (NotFound): secrets ":" not found
Error from server (NotFound): secrets "1b2afbf1-f5b7-48dd-aee1-fa8d1831423c" not found
Error from server (NotFound): secrets "9364ff59-6372-416c-9666-665698a9828e\"}]}}" not found
```
Apparently the `cut` command was not isolating only the deployment uid, resulting in an unexpected value being stored in `DEPLOYMENT_UID`. This PR uses jsonpath to isolate the value, which is simpler and more accurate than `cut`.

I also found that when deleting the konk CR very soon after creating it, the secrets were getting left behind. This is because the provisioning script was waiting for the konk apiserver to be ready rather than just waiting for the deployment to exist. This was resolved by switching from `condition=available` to `condition=progressing`.