### PR TITLE
Set best practice Container Image Pull Policy

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
           make docker-build
           VERSION=$(git describe --always --long --tags)
           kind load docker-image infoblox/konk:$VERSION --name chart-testing
-          make deploy-konk-operator HELM_FLAGS="--wait --set=image.tag=$VERSION"
+          make deploy-konk-operator HELM_FLAGS="--wait --set=image.tag=$VERSION --set=image.pullPolicy=IfNotPresent"
           kubectl create -f examples/konk.yaml
           until kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/instance=example-konk
           do

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ helm-lint: helm-lint-$(notdir $(CHART_DIR)/*)
 helm-lint-%:
 	$(HELM) lint $(CHART_DIR)/$*
 
-%-konk-operator: HELM_FLAGS += --set=image.tag=$(GIT_VERSION) --crds.create=true
+%-konk-operator: HELM_FLAGS ?= --set=image.tag=$(GIT_VERSION) --set=image.pullPolicy=IfNotPresent --crds.create=true
 
 deploy-%: package
 	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$* $(HELM_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ helm-lint: helm-lint-$(notdir $(CHART_DIR)/*)
 helm-lint-%:
 	$(HELM) lint $(CHART_DIR)/$*
 
-%-konk-operator: HELM_FLAGS ?= --set=image.tag=$(GIT_VERSION) --set=image.pullPolicy=IfNotPresent --crds.create=true
+%-konk-operator: HELM_FLAGS ?= --set=image.tag=$(GIT_VERSION) --set=image.pullPolicy=IfNotPresent
 
 deploy-%: package
 	$(HELM) upgrade -i $(RELEASE_NAME)-$* $(CHART_DIR)/$* $(HELM_FLAGS)

--- a/helm-charts/konk-operator/values.yaml
+++ b/helm-charts/konk-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: infoblox/konk
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 apiserver:
   image:
     repository: k8s.gcr.io/kube-apiserver
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
   resources: {}
@@ -45,7 +45,7 @@ apiserver:
 etcd:
   image:
     repository: k8s.gcr.io/etcd
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
     tag: "3.4.9-1" # keep image versions in sync with `kubeadm config images list`
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -69,7 +69,7 @@ etcd:
 kind:
   image:
     repository: kindest/node
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
   resources: {}


### PR DESCRIPTION
    · konk-operator -> ImagePullPolicy is not set to Always
        It's recommended to always set the ImagePullPolicy to Always, to
        make sure that the imagePullSecrets are always correct, and to
        always get the image you want.