### PR TITLE
fix etcd liveness probe

### DIFF
--- a/helm-charts/konk/templates/deployment.yaml
+++ b/helm-charts/konk/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
               path: /healthz
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /healthz

--- a/helm-charts/konk/templates/deployment.yaml
+++ b/helm-charts/konk/templates/deployment.yaml
@@ -89,13 +89,12 @@ spec:
             - --client-cert-auth=true
             - --key-file=/etc/kubernetes/pki/apiserver/etcd/server.key
             - --listen-client-urls=https://127.0.0.1:2379
-            - --listen-metrics-urls=http://127.0.0.1:2381
+            - --listen-metrics-urls=http://0.0.0.0:2381
             - --name={{ .Chart.Name }}
             - --trusted-ca-file=/etc/kubernetes/pki/apiserver/etcd/ca.crt
           livenessProbe:
             failureThreshold: 8
             httpGet:
-              host: 127.0.0.1
               path: /health
               port: 2381
               scheme: HTTP


### PR DESCRIPTION
This adds initial delay to the apiserver liveness probe. ~This should fix the CrashLoopBackoff errors caused by etcd not being ready fast enough before the apiserver liveness probe fails.~ This is only needed on Kubernetes deployments that don't support startupProbe.

Root cause of the liveness probe failing on some environments is because of how their pod networking is configured. In Minikube, it always works. In more traditional deployments, the node needs to be able to access the etcd container's health/metrics port, which requires that it listen on the pod IP, not just localhost.