### PR TITLE
Fix deployment rbac

### DIFF
--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -30,9 +30,9 @@ then
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi
 
-kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployment -l app.kubernetes.io/instance=$FULLNAME
+kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$FULLNAME
 
-DEPLOYMENT_UID=$(kubectl get deploy -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
+DEPLOYMENT_UID=$(kubectl get deployments.apps -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
 for name in apiserver-cert etcd-cert kubeconfig
 do
   kubectl patch -n $NAMESPACE secret $FULLNAME-$name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'


### PR DESCRIPTION
I'm seeing errors like this in the provisioning script on older clusters:
```
+ kubectl -n thayward-demo wait --timeout=3m --for=condition=progressing deployment -l app.kubernetes.io/instance=example-konk
Error from server (Forbidden): deployments.extensions is forbidden: User "system:serviceaccount:thayward-demo:example-konk" cannot list resource "deployments" in API group "extensions" in the namespace "thayward-demo"
```
The shorthand `kubectl get deploy` was matching the older deployment api group, `extensions/v1beta1`, but the rbac only has permission on `apps`. If we explicitly request `deployments.apps`, it succeeds.