### PR TITLE
Create Issuer and Certificate resources for allowing public authenticated traffic

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Test konk chart
         run: |
           kubectl cluster-info
+          make deploy-cert-manager
           make deploy-konk
           make test-konk
       - name: Test konk-operator
@@ -26,6 +27,7 @@ jobs:
           make docker-build
           VERSION=$(git describe --always --long --tags)
           kind load docker-image infoblox/konk:$VERSION --name chart-testing
+          make deploy-cert-manager
           make deploy-konk-operator HELM_FLAGS="--set=image.tag=$VERSION --set=image.pullPolicy=IfNotPresent"
           kubectl create -f examples/konk.yaml
           until kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/instance=example-konk

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,6 @@ jobs:
           make docker-build
           VERSION=$(git describe --always --long --tags)
           kind load docker-image infoblox/konk:$VERSION --name chart-testing
-          make deploy-cert-manager
           make deploy-konk-operator HELM_FLAGS="--set=image.tag=$VERSION --set=image.pullPolicy=IfNotPresent"
           kubectl create -f examples/konk.yaml
           until kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/instance=example-konk

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ helm-lint-%:
 
 deploy-cert-manager:
 	kubectl create namespace cert-manager
-	$(HELM) install --wait cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
+	$(HELM) upgrade -i --wait cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
 		--set installCRDs=true \
 		--set extraArgs[0]="--enable-certificate-owner-ref=true"
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ helm-lint-%:
 
 deploy-cert-manager:
 	kubectl create namespace cert-manager
-	$(HELM) install cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
+	$(HELM) install --wait cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
 		--set installCRDs=true \
 		--set extraArgs[0]="--enable-certificate-owner-ref=true"
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ helm-lint: helm-lint-$(notdir $(CHART_DIR)/*)
 helm-lint-%:
 	$(HELM) lint $(CHART_DIR)/$*
 
+deploy-cert-manager:
+	kubectl create namespace cert-manager
+	$(HELM) repo add jetstack https://charts.jetstack.io
+	$(HELM) install cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
+		--set installCRDs=true \
+		--set extraArgs[0]="--enable-certificate-owner-ref=true"
+
 %-konk-operator: HELM_FLAGS ?= --set=image.tag=$(GIT_VERSION) --set=image.pullPolicy=IfNotPresent
 
 deploy-%: package

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ helm-lint-%:
 	$(HELM) lint $(CHART_DIR)/$*
 
 deploy-cert-manager:
-	kubectl create namespace cert-manager
 	$(HELM) upgrade -i --wait cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
+		--create-namespace \
 		--set installCRDs=true \
 		--set extraArgs[0]="--enable-certificate-owner-ref=true"
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ HELM		?= docker run --rm -i \
 			-e KUBECONFIG=/apps/.kube/$(notdir $(KUBECONFIG)) \
 			-v $(dir $(KUBECONFIG)):/apps/.kube/ \
 			-v $(PWD):/apps \
-			-u $(shell id -u):$(shell id -g) \
+			-v $(PWD)/repositories.yaml:/tmp/.config/helm/repositories.yaml \
+			-v $(PWD)/jetstack-index.yaml:/tmp/.cache/helm/repository/jetstack-index.yaml \
 			infoblox/helm:3.2.4-5b243a2 \
 			helm
 K8S_RELEASE	?= v1.19.0
@@ -30,7 +31,6 @@ helm-lint-%:
 
 deploy-cert-manager:
 	kubectl create namespace cert-manager
-	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) install cert-manager --namespace cert-manager jetstack/cert-manager --version v1.0.1 \
 		--set installCRDs=true \
 		--set extraArgs[0]="--enable-certificate-owner-ref=true"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,7 +68,9 @@ rules:
   - "roles"
   - "rolebindings"
 - verbs:
-  - "*"
+  - get
+  - create
+  - list
   apiGroups:
   - "cert-manager.io"
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,5 +67,12 @@ rules:
   resources:
   - "roles"
   - "rolebindings"
+- verbs:
+  - "*"
+  apiGroups:
+  - "cert-manager.io"
+  resources:
+  - "issuers"
+  - "certificates"
 
 # +kubebuilder:scaffold:rules

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -23,6 +23,14 @@ then
     --from-file=/etc/kubernetes/pki/apiserver-etcd-client.key
   kubectl -n $NAMESPACE label secret $FULLNAME-apiserver-cert $LABELS
 fi
+if ! kubectl -n $NAMESPACE get secret $FULLNAME-ca
+then
+  kubectl -n $NAMESPACE create secret tls $FULLNAME-ca \
+    --cert=/etc/kubernetes/pki/ca.crt \
+    --key=/etc/kubernetes/pki/ca.key
+  kubectl -n $NAMESPACE label secret $FULLNAME-ca $LABELS
+fi
+
 if ! kubectl -n $NAMESPACE get secret $FULLNAME-kubeconfig
 then
   kubectl -n $NAMESPACE create secret generic $FULLNAME-kubeconfig \
@@ -33,7 +41,7 @@ fi
 kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$FULLNAME
 
 DEPLOYMENT_UID=$(kubectl get deployments.apps -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
-for name in apiserver-cert etcd-cert kubeconfig
+for name in apiserver-cert etcd-cert ca kubeconfig
 do
   kubectl patch -n $NAMESPACE secret $FULLNAME-$name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 done

--- a/helm-charts/konk/templates/certificate.yaml
+++ b/helm-charts/konk/templates/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ include "konk.fullname" . }}-certificate
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "konk.fullname" . }}-generated-cert
+  dnsNames:
+  - {{ include "konk.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: {{ include "konk.fullname" . }}-ca-issuer
+    kind: Issuer

--- a/helm-charts/konk/templates/certificate.yaml
+++ b/helm-charts/konk/templates/certificate.yaml
@@ -1,8 +1,10 @@
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: {{ include "konk.fullname" . }}-certificate
+  name: {{ include "konk.fullname" . }}-ingress-client
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konk.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk.fullname" . }}-generated-cert
   dnsNames:

--- a/helm-charts/konk/templates/issuer.yaml
+++ b/helm-charts/konk/templates/issuer.yaml
@@ -3,6 +3,8 @@ kind: Issuer
 metadata:
   name: {{ include "konk.fullname" . }}-ca-issuer
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konk.labels" . | nindent 4 }}
 spec:
   ca:
     secretName: {{ include "konk.fullname" . }}-ca

--- a/helm-charts/konk/templates/issuer.yaml
+++ b/helm-charts/konk/templates/issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ include "konk.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "konk.fullname" . }}-ca

--- a/jetstack-index.yaml
+++ b/jetstack-index.yaml
@@ -1,0 +1,1098 @@
+apiVersion: v1
+entries:
+  cert-manager:
+  - apiVersion: v1
+    appVersion: v1.0.2
+    created: "2020-09-22T14:25:09.38Z"
+    description: A Helm chart for cert-manager
+    digest: 7a8c0600c28b0eec8f251e4dffdc7c969422773d87099a914fc83713b1a5c838
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.2.tgz
+    version: v1.0.2
+  - apiVersion: v1
+    appVersion: v1.0.1
+    created: "2020-09-04T19:21:58.086Z"
+    description: A Helm chart for cert-manager
+    digest: d4af85399dac09c8db261e8d9366f7a1b3d7b1d6c8ee26b452631840fe22268f
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.1.tgz
+    version: v1.0.1
+  - apiVersion: v1
+    appVersion: v1.0.0
+    created: "2020-09-02T09:55:46.706Z"
+    description: A Helm chart for cert-manager
+    digest: b6d62727cded8c74087428f605ff8710b9495f2a8896bb3245d75b1f14989242
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.0.tgz
+    version: v1.0.0
+  - apiVersion: v1
+    appVersion: v1.0.0-beta.1
+    created: "2020-08-27T15:49:07.992Z"
+    description: A Helm chart for cert-manager
+    digest: fc1520dd406ad1123c099d96a125bf3a5c25165731594d595adab9597ad6426d
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.0-beta.1.tgz
+    version: v1.0.0-beta.1
+  - apiVersion: v1
+    appVersion: v1.0.0-beta.0
+    created: "2020-08-21T11:59:51.105Z"
+    description: A Helm chart for cert-manager
+    digest: 7db2a37a78482b83167846ccebd39e33730a77daa8804c7da1c5103a3459ac6e
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.0-beta.0.tgz
+    version: v1.0.0-beta.0
+  - apiVersion: v1
+    appVersion: v1.0.0-alpha.1
+    created: "2020-08-17T11:42:20.3Z"
+    description: A Helm chart for cert-manager
+    digest: 49c36aa5b0b019225b153c98a480a4317cf50ed69c101a749e4584eb7f31412f
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.0-alpha.1.tgz
+    version: v1.0.0-alpha.1
+  - apiVersion: v1
+    appVersion: v1.0.0-alpha.0
+    created: "2020-08-12T13:53:30.744Z"
+    description: A Helm chart for cert-manager
+    digest: 1850a290a42ed423125dc95010fbcd4f1b401f7ab28336157b4b3c28c4db58b8
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v1.0.0-alpha.0.tgz
+    version: v1.0.0-alpha.0
+  - apiVersion: v1
+    appVersion: v0.16.1
+    created: "2020-08-07T09:35:34.559Z"
+    description: A Helm chart for cert-manager
+    digest: 690a2c066fd823e39115b46568ac1c24c5fd46d290fead4c2572636b45d260f3
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.16.1.tgz
+    version: v0.16.1
+  - apiVersion: v1
+    appVersion: v0.16.0
+    created: "2020-07-23T15:25:29.712Z"
+    description: A Helm chart for cert-manager
+    digest: fb0f13bed040e565e5cacbef41a25c551b0b2dc0383f0cb87cf30d27408b198e
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.16.0.tgz
+    version: v0.16.0
+  - apiVersion: v1
+    appVersion: v0.16.0-alpha.1
+    created: "2020-07-16T12:51:17.597Z"
+    description: A Helm chart for cert-manager
+    digest: be1171b0a62f7fcabe8d7bfff3d6bf37be05b4db8fd653179eb09ea485d4f1d6
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.16.0-alpha.1.tgz
+    version: v0.16.0-alpha.1
+  - apiVersion: v1
+    appVersion: v0.16.0-alpha.0
+    created: "2020-07-07T13:48:07.222Z"
+    description: A Helm chart for cert-manager
+    digest: ac1a01346e7871b7f4c8f0323ce7a82b0049d34a33e9b427ab338e923b0c8ac0
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.16.0-alpha.0.tgz
+    version: v0.16.0-alpha.0
+  - apiVersion: v1
+    appVersion: v0.15.2
+    created: "2020-07-01T17:17:13.556Z"
+    description: A Helm chart for cert-manager
+    digest: ee1b94d9e2c679a6284669749f7186f5ded227a4675488aebfdd491efbdbfcec
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.2.tgz
+    version: v0.15.2
+  - apiVersion: v1
+    appVersion: v0.15.1
+    created: "2020-05-27T13:18:43.916Z"
+    description: A Helm chart for cert-manager
+    digest: f446f7a24ea0be194dced2842d9aef2419ba68eca8d43f3060bc88f72844fe94
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.1.tgz
+    version: v0.15.1
+  - apiVersion: v1
+    appVersion: v0.15.0
+    created: "2020-05-06T12:08:41.242Z"
+    description: A Helm chart for cert-manager
+    digest: 9ac0ac003cb5ddf6bbf8836fc52f300b974e5c1d5870cbe30553f5ea330fd1a4
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0.tgz
+    version: v0.15.0
+  - apiVersion: v1
+    appVersion: v0.15.0-beta.1
+    created: "2020-05-04T15:51:18.288Z"
+    description: A Helm chart for cert-manager
+    digest: 76ac113120cd1a2e83209473d919b873ed020f30b02a1fd32bf94564cb11b7d4
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0-beta.1.tgz
+    version: v0.15.0-beta.1
+  - apiVersion: v1
+    appVersion: v0.15.0-beta.0
+    created: "2020-04-30T16:07:02.918Z"
+    description: A Helm chart for cert-manager
+    digest: 5c3b489e368bbb222bf709517a41f8bb628ecfe3ca58b3b3175df428ae3c0b26
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0-beta.0.tgz
+    version: v0.15.0-beta.0
+  - apiVersion: v1
+    appVersion: v0.15-alpha.3
+    created: "2020-04-29T13:05:38.774Z"
+    description: A Helm chart for cert-manager
+    digest: c943498ddb8479c2cdb17790b434af5295b71854a2aff120d0249fb88416c8c9
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15-alpha.3.tgz
+    version: v0.15-alpha.3
+  - apiVersion: v1
+    appVersion: v0.15.0-alpha.2
+    created: "2020-04-23T17:43:40.584Z"
+    description: A Helm chart for cert-manager
+    digest: 3eb0616c15bd1095325429b31b52130dfc2b87e80984890aece4073ca7082148
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0-alpha.2.tgz
+    version: v0.15.0-alpha.2
+  - apiVersion: v1
+    appVersion: v0.15.0-alpha.1
+    created: "2020-04-22T18:36:56.215Z"
+    description: A Helm chart for cert-manager
+    digest: 76e363b0ca53cd170d66ec5201070789461e83487a69c7403f4baa175bd464a0
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0-alpha.1.tgz
+    version: v0.15.0-alpha.1
+  - apiVersion: v1
+    appVersion: v0.15.0-alpha.0
+    created: "2020-04-08T15:53:42.944Z"
+    description: A Helm chart for cert-manager
+    digest: 5de42e6f0ad1192fe0b24e156a9006afb24e2d19315adb4b37d82e4f5f762ddc
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.15.0-alpha.0.tgz
+    version: v0.15.0-alpha.0
+  - apiVersion: v1
+    appVersion: v0.14.3
+    created: "2020-04-29T08:54:51.412Z"
+    description: A Helm chart for cert-manager
+    digest: 3563c03a7c2433167b5f5a3f10df7a21ebc9cc31cc9f99153a06edc3fde242b6
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.3.tgz
+    version: v0.14.3
+  - apiVersion: v1
+    appVersion: v0.14.2
+    created: "2020-04-08T11:38:26.281Z"
+    description: A Helm chart for cert-manager
+    digest: 160e1bd4906855b91c8ba42afe10af2d0443b184916e4534175890b1a7278f4e
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.2.tgz
+    version: v0.14.2
+  - apiVersion: v1
+    appVersion: v0.14.1
+    created: "2020-03-25T18:30:16.354Z"
+    description: A Helm chart for cert-manager
+    digest: 629150400487df41af6c7acf2a3bfd8e691f657a930bc81e1dcf3b9d23329baf
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.1.tgz
+    version: v0.14.1
+  - apiVersion: v1
+    appVersion: v0.14.0
+    created: "2020-03-11T13:41:55.729Z"
+    description: A Helm chart for cert-manager
+    digest: 4b64f19031c1574b40b566381ea90dd9d912c09d3c736355117bf059d5fca36a
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.0.tgz
+    version: v0.14.0
+  - apiVersion: v1
+    appVersion: v0.14.0-alpha.1
+    created: "2020-03-06T13:41:10.607Z"
+    description: A Helm chart for cert-manager
+    digest: 410193cf08fa76495a2a0d0808f5d170e2b0e184b10b8bb6b6e55b0d8f0e9a6b
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.0-alpha.1.tgz
+    version: v0.14.0-alpha.1
+  - apiVersion: v1
+    appVersion: v0.14.0-alpha.0
+    created: "2020-03-05T11:04:34.07Z"
+    description: A Helm chart for cert-manager
+    digest: b0ba1ff006d2823d64f34573e85445fcb776b1721fb0deb122f149feda3bcc9a
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.14.0-alpha.0.tgz
+    version: v0.14.0-alpha.0
+  - apiVersion: v1
+    appVersion: v0.13.1
+    created: "2020-02-18T13:23:13.134Z"
+    description: A Helm chart for cert-manager
+    digest: 07a60bda908ed8b14aef0f3ad3867f394dd7dc8001d74424abd3daaafc709a64
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.13.1.tgz
+    version: v0.13.1
+  - apiVersion: v1
+    appVersion: v0.13.0
+    created: "2020-01-21T18:35:57.114Z"
+    description: A Helm chart for cert-manager
+    digest: e89bdb41db004da7c46d92c087ccfa672779e9b56a0a188be3d461930e28d9e9
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.13.0.tgz
+    version: v0.13.0
+  - apiVersion: v1
+    appVersion: v0.13.0-alpha.0
+    created: "2019-12-16T12:38:41.46Z"
+    description: A Helm chart for cert-manager
+    digest: cde674a080e7cb6307dea0380c80772d453bc78564af838ac48ae7ff18016899
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.13.0-alpha.0.tgz
+    version: v0.13.0-alpha.0
+  - apiVersion: v1
+    appVersion: v0.12.0
+    created: "2019-11-28T13:11:30.845Z"
+    description: A Helm chart for cert-manager
+    digest: 7b42b4927bbcc04fa8c3aee9a86596ad5f020866b566ff78eba7f2fd704956f9
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.12.0.tgz
+    version: v0.12.0
+  - apiVersion: v1
+    appVersion: v0.12.0-beta.1
+    created: "2019-11-15T17:15:44.27Z"
+    description: A Helm chart for cert-manager
+    digest: fb34babe9a4a505a7f5a1fcf231970c037f9b50fe2be8d5c87e24298407cc9a0
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.12.0-beta.1.tgz
+    version: v0.12.0-beta.1
+  - apiVersion: v1
+    appVersion: v0.12.0-beta.0
+    created: "2019-11-14T11:49:12.252Z"
+    description: A Helm chart for cert-manager
+    digest: 95c4ec8297366d467f9eb83b30b018af6e0550311a7daa3a034ad7945005ef4b
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.12.0-beta.0.tgz
+    version: v0.12.0-beta.0
+  - apiVersion: v1
+    appVersion: v0.11.1
+    created: "2019-11-27T23:14:13.26Z"
+    description: A Helm chart for cert-manager
+    digest: 0aea3737850dfac9c9ab54bd3fdd16c4b7d8bdb84c42c1982cadc2ad8468d305
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.11.1.tgz
+    version: v0.11.1
+  - appVersion: v0.11.0
+    created: "2019-10-10T13:57:16.097Z"
+    description: A Helm chart for cert-manager
+    digest: 41826c830da91f45c816931707c05736766e4014c579d29b9def46fa211e9d30
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.11.0.tgz
+    version: v0.11.0
+  - appVersion: v0.11.0-beta.0
+    created: "2019-10-03T12:23:26.538Z"
+    description: A Helm chart for cert-manager
+    digest: 355b2326554a9f12e6d9909a57cf7e1f92b31a153dd358e3f27cf44933fc192f
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.11.0-beta.0.tgz
+    version: v0.11.0-beta.0
+  - appVersion: v0.10.1
+    created: "2019-09-27T12:36:33.775Z"
+    description: A Helm chart for cert-manager
+    digest: bf43465e42bb6b5c29c66b22bfa02702cf890e53c9c44d8f8fc43f4e6c8d9499
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.10.1.tgz
+    version: v0.10.1
+  - appVersion: v0.10.0
+    created: "2019-09-05T14:22:01.512Z"
+    description: A Helm chart for cert-manager
+    digest: 33a7abb67820db9568224d0ba824f87254294a09f3f7c030d34934b83ded2987
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.10.0.tgz
+    version: v0.10.0
+  - appVersion: v0.10.0-alpha.0
+    created: "2019-08-20T16:15:05.912Z"
+    description: A Helm chart for cert-manager
+    digest: 8d0fa1db51e58a328a5dd0cd8e6193fb6cf072eb796690cf5a9d34c71ea58fe0
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.10.0-alpha.0.tgz
+    version: v0.10.0-alpha.0
+  - appVersion: v0.9.1
+    created: "2019-08-13T14:01:31.885Z"
+    description: A Helm chart for cert-manager
+    digest: 0d16e7f3205ced4e5c4fa39dd58d7989b814770a884c7f1f3ffdbe7b38a32e0d
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.9.1.tgz
+    version: v0.9.1
+  - appVersion: v0.9.0
+    created: "2019-07-23T17:39:20.557Z"
+    description: A Helm chart for cert-manager
+    digest: eaaefc80a597c8bc7dd396201b104236ca991bd78966facc27dd30c8eb75f07c
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.9.0.tgz
+    version: v0.9.0
+  - appVersion: v0.9.0-beta.0
+    created: "2019-07-17T18:07:44.179Z"
+    description: A Helm chart for cert-manager
+    digest: ade3931571d4a58d965da29d4c3c66e0b4132da00f58b1c36d7c55a94137d935
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.9.0-beta.0.tgz
+    version: v0.9.0-beta.0
+  - appVersion: v0.9.0-alpha.0
+    created: "2019-07-08T16:03:27.017Z"
+    description: A Helm chart for cert-manager
+    digest: 8a2771f27e96d4b19f8c78f615aec1fdd1a0cb1047bca4a3195ee65d40ea07f0
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.9.0-alpha.0.tgz
+    version: v0.9.0-alpha.0
+  - appVersion: v0.8.1
+    created: "2019-06-18T15:04:54.287Z"
+    description: A Helm chart for cert-manager
+    digest: ff8d3acff2fd8198ce109b1dd6ae926af5dadf22144bbb15eb3206548df47342
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.8.1.tgz
+    version: v0.8.1
+  - appVersion: v0.8.0
+    created: "2019-05-20T17:12:39.532Z"
+    description: A Helm chart for cert-manager
+    digest: 3bb2261bf27f8f19fc2fa8a1e060dd7303c8dfbeab13bbeabfcf2bae7919063f
+    home: https://github.com/jetstack/cert-manager
+    icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.8.0.tgz
+    version: v0.8.0
+  - appVersion: v0.8.0-beta.0
+    created: "2019-05-07T13:22:11.191Z"
+    description: A Helm chart for cert-manager
+    digest: 451d50cd09ad36335c44e60f42a4db74b700b758e2527b17d2b3b32a8d578ec8
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.8.0-beta.0.tgz
+    version: v0.8.0-beta.0
+  - appVersion: v0.8.0-alpha.0
+    created: "2019-05-01T17:20:00.514Z"
+    description: A Helm chart for cert-manager
+    digest: 802ccb261e6cda4190f1ce45802e9e27c97147314a85c98754331da3eba85d2d
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.8.0-alpha.0.tgz
+    version: v0.8.0-alpha.0
+  - appVersion: v0.7.2
+    created: "2019-05-01T18:14:52.318Z"
+    description: A Helm chart for cert-manager
+    digest: e0596b237981dd6e478a7036521a8d3f805eb6fa0e03e9be7ee3e49af2dd640f
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.7.2.tgz
+    version: v0.7.2
+  - appVersion: v0.7.1
+    created: "2019-04-24T13:17:11.214Z"
+    description: A Helm chart for cert-manager
+    digest: 6196e099d9b8c72f706dbe1a8aea2ab2c17ff1f8c7310d0aaae96c8c0d65bb50
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.7.1.tgz
+    version: v0.7.1
+  - appVersion: v0.7.0
+    created: "2019-03-11T18:22:58.295Z"
+    description: A Helm chart for cert-manager
+    digest: d5f0b603126b2933ef85ece47ccdf276d98f00c5c3f25d7901e3b1188d6c9052
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.7.0.tgz
+    version: v0.7.0
+  - appVersion: v0.7.0-beta.0
+    created: "2019-03-02T12:11:25.974Z"
+    description: A Helm chart for cert-manager
+    digest: 48cc6ed22c18320b873c28ffab8b0cab5f5d9b92aa76428a7a132dce21367c76
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.7.0-beta.0.tgz
+    version: v0.7.0-beta.0
+  - appVersion: v0.7.0-alpha.0
+    created: "2019-02-22T15:15:51.922Z"
+    description: A Helm chart for cert-manager
+    digest: f004ce4e66691e9f2df382ee901cbae68568d2eabff993bd6ebbcbfb601f334a
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.7.0-alpha.1.tgz
+    version: v0.7.0-alpha.1
+  - appVersion: v0.6.0
+    created: "2019-01-23T14:12:14.413Z"
+    description: A Helm chart for cert-manager
+    digest: 28e5a8d8b6229b33026bfe28a81a92cf5ff94366c56ef86a54afc69889b3cd1c
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.6.0.tgz
+    version: v0.6.0
+  - appVersion: v0.5.2
+    created: "2018-12-11T17:31:41.836Z"
+    description: A Helm chart for cert-manager
+    digest: 5a2081b9532be8ba5b1cf2f37d812fe679eddb2640eecc297bcd8ebe79cb7719
+    home: https://github.com/jetstack/cert-manager
+    keywords:
+    - cert-manager
+    - kube-lego
+    - letsencrypt
+    - tls
+    maintainers:
+    - email: james@jetstack.io
+      name: munnerz
+    name: cert-manager
+    sources:
+    - https://github.com/jetstack/cert-manager
+    urls:
+    - charts/cert-manager-v0.5.2.tgz
+    version: v0.5.2
+  tor-proxy:
+  - apiVersion: v1
+    created: "2018-11-16T09:23:13.538Z"
+    description: A Helm chart for Kubernetes
+    digest: 1d2fd11e22ba58bf0a263c39777f0f18855368b099aed7b03123ca91e55343e4
+    name: tor-proxy
+    urls:
+    - charts/tor-proxy-0.1.1.tgz
+    version: 0.1.1
+generated: "2020-09-22T14:25:10Z"
+serverInfo: null

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,0 +1,11 @@
+apiVersion: ""
+generated: "0001-01-01T00:00:00Z"
+repositories:
+- caFile: ""
+  certFile: ""
+  insecure_skip_tls_verify: false
+  keyFile: ""
+  name: jetstack
+  password: ""
+  url: https://charts.jetstack.io
+  username: ""


### PR DESCRIPTION
Added code to create an Issuer and Certificate (Cert-manager CRDs), which creates a secret to be referenced to by service ingress object.

Generates the following objects - 

 Issuer - 

```
konk abalavenkata(k8s: minikube) $ kubectl get issuer -n ab -o yaml
apiVersion: v1
items:
- apiVersion: cert-manager.io/v1
  kind: Issuer
  metadata:
    annotations:
      meta.helm.sh/release-name: abalavenkata-konk
      meta.helm.sh/release-namespace: ab
    creationTimestamp: "2020-09-25T04:13:24Z"
    generation: 1
    labels:
      app.kubernetes.io/managed-by: Helm
    name: abalavenkata-konk-ca-issuer
    namespace: ab
    resourceVersion: "2374043"
    selfLink: /apis/cert-manager.io/v1/namespaces/ab/issuers/abalavenkata-konk-ca-issuer
    uid: d895ff41-4850-427f-bc93-03e04e5faff4
  spec:
    ca:
      secretName: abalavenkata-konk-ca
  status:
    conditions:
    - lastTransitionTime: "2020-09-25T04:14:18Z"
      message: Signing CA verified
      reason: KeyPairVerified
      status: "True"
      type: Ready
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Certificate -

```
konk abalavenkata(k8s: minikube) $ kubectl get certificate -n ab -o yaml
apiVersion: v1
items:
- apiVersion: cert-manager.io/v1
  kind: Certificate
  metadata:
    annotations:
      meta.helm.sh/release-name: abalavenkata-konk
      meta.helm.sh/release-namespace: ab
    creationTimestamp: "2020-09-25T04:13:24Z"
    generation: 1
    labels:
      app.kubernetes.io/managed-by: Helm
    name: abalavenkata-konk-certificate
    namespace: ab
    resourceVersion: "2374068"
    selfLink: /apis/cert-manager.io/v1/namespaces/ab/certificates/abalavenkata-konk-certificate
    uid: 05b1eb7a-7c96-46e3-af41-7963728c2b07
  spec:
    dnsNames:
    - abalavenkata-konk.ab.svc.cluster.local
    issuerRef:
      kind: Issuer
      name: abalavenkata-konk-ca-issuer
    secretName: abalavenkata-konk-generated-cert
  status:
    conditions:
    - lastTransitionTime: "2020-09-25T04:14:20Z"
      message: Certificate is up to date and has not expired
      reason: Ready
      status: "True"
      type: Ready
    notAfter: "2020-12-24T04:14:19Z"
    notBefore: "2020-09-25T04:14:19Z"
    renewalTime: "2020-11-24T04:14:19Z"
    revision: 1
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Generated Secret - 

```
konk abalavenkata(k8s: minikube) $ kubectl get secret -n ab
NAME                                      TYPE                                  DATA   AGE
abalavenkata-konk-apiserver-cert          Opaque                                6      26m
abalavenkata-konk-ca                      kubernetes.io/tls                     2      26m
abalavenkata-konk-etcd-cert               Opaque                                3      26m
abalavenkata-konk-generated-cert          kubernetes.io/tls                     3      25m <<<<<< GENERATED CERT
abalavenkata-konk-kubeconfig              Opaque                                1      26m
abalavenkata-konk-token-wlxgk             kubernetes.io/service-account-token   3      26m
default-token-mdz57                       kubernetes.io/service-account-token   3      21d
sh.helm.release.v1.abalavenkata-konk.v1   helm.sh/release.v1                    1      26m

```
**!TEST PENDING!**