### PR TITLE
Fix Provision.sh script

### DIFF
--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -38,7 +38,7 @@ then
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
 fi
 
-kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$FULLNAME
+kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$RELEASE
 
 DEPLOYMENT_UID=$(kubectl get deployments.apps -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
 for name in apiserver-cert etcd-cert ca kubeconfig


### PR DESCRIPTION
Fix for - https://infoblox.atlassian.net/browse/ATLAS-8136

Looks like the `provision.sh` script was expecting the deployment label `app.kubernetes.io/instance` to hold the fullname (Release Name + Chart Name) instead of just the release-name. This caused a conflict with the selectorLabels value which stores the release-name.

DEMO - 

Existing behavior -

```
kubectl -n default wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=example-konk
error: no matching resources found
```

Deployed a test Konk with the name - example. Observed the logs below in init container.

```
kubectl -n default wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=example
deployment.apps/example-konk condition met
deployment.apps/example-konk-init condition met
```