### PR TITLE
Use the service name in the certificate dns names

### DIFF
--- a/helm-charts/konk-service/templates/certificate.yaml
+++ b/helm-charts/konk-service/templates/certificate.yaml
@@ -10,6 +10,6 @@ spec:
   issuerRef:
     name: {{ include "konk-service.fullname" . }}-ca
   dnsNames:
-  - {{ include "konk-service.fullname" . }}
-  - {{ include "konk-service.fullname" . }}.{{ .Release.Namespace }}
-  - {{ include "konk-service.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ .Values.service.name }}
+  - {{ .Values.service.name }}.{{ .Release.Namespace }}
+  - {{ .Values.service.name }}.{{ .Release.Namespace }}.svc


### PR DESCRIPTION
Fixes the error:

    E1024 00:41:26.255482       1 controller.go:116] loading OpenAPI spec for "v1alpha1.tagging.bulk.infoblox.com" failed with: failed to retrieve openAPI spec, http error: ResponseCode: 503, Body: error trying to reach service: x509: certificate is valid for tagging-api-tagging-apiserver-apiservice-konk-service, tagging-api-tagging-apiserver-apiservice-konk-service.tagging-v2, tagging-api-tagging-apiserver-apiservice-konk-service.tagging-v2.svc, not tagging-api-tagging-apiserver-apiservice.tagging-v2.svc