### PR TITLE
Don't put -konk in kubeconfig name

### DIFF
--- a/helm-charts/konk-service/templates/configmap.yaml
+++ b/helm-charts/konk-service/templates/configmap.yaml
@@ -13,7 +13,16 @@ data:
     CERT=$(cat certs/ca.crt | base64)
     CERT=${CERT//$'\n'/}
     cat /mounts/api-service.yaml.in | sed "s/{{` {{ SERVICENAME }} `}}/${SERVICENAME}/g" | sed "s/{{` {{ NAMESPACE }} `}}/${NAMESPACE}/g" | sed "s/{{` {{ CERT }} `}}/${CERT}/g" > /gen/api-service.yaml
-    kubectl apply -f /gen/api-service.yaml
+    delay=2
+    until kubectl apply -f /gen/api-service.yaml
+    do
+      sleep $delay
+      let delay="delay*2"
+      if [ "$delay" -gt "60" ]
+      then
+        delay=60
+      fi
+    done
     INSTALL=install
     if [ $CRDS == $INSTALL ]
     then

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -31,17 +31,17 @@ then
   kubectl -n $NAMESPACE label secret $FULLNAME-ca $LABELS
 fi
 
-if ! kubectl -n $NAMESPACE get secret $FULLNAME-kubeconfig
+if ! kubectl -n $NAMESPACE get secret $RELEASE-kubeconfig
 then
-  kubectl -n $NAMESPACE create secret generic $FULLNAME-kubeconfig \
+  kubectl -n $NAMESPACE create secret generic $RELEASE-kubeconfig \
     --from-file=/etc/kubernetes/admin.conf
-  kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
+  kubectl -n $NAMESPACE label secret $RELEASE-kubeconfig $LABELS
 fi
 
 kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$RELEASE
 
 DEPLOYMENT_UID=$(kubectl get deployments.apps -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
-for name in apiserver-cert etcd-cert ca kubeconfig
+for name in $FULLNAME-apiserver-cert $FULLNAME-etcd-cert $FULLNAME-ca $RELEASE-kubeconfig
 do
-  kubectl patch -n $NAMESPACE secret $FULLNAME-$name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
+  kubectl patch -n $NAMESPACE secret $name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 done


### PR DESCRIPTION
By using the exact release name (not a template) to build the kubeconfig name, it is easier for other charts that need to reference that kubeconfig to predict the secret name. Before this, the logic of the fullname template would sometimes insert `-konk` into the name and sometimes not, making it difficult to predict (dependent charts do not have access to konk's fullname template use it to generate the secret name directly).