### PR TITLE
Define default resources for konk

### DIFF
--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -10,17 +10,13 @@ apiserver:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 20m
+      memory: 160Mi
   securityContext: {}
     # capabilities:
     #   drop:
@@ -47,17 +43,13 @@ etcd:
     repository: k8s.gcr.io/etcd
     pullPolicy: Always
     tag: "3.4.9-1" # keep image versions in sync with `kubeadm config images list`
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
   securityContext: {}
     # capabilities:
     #   drop:
@@ -72,17 +64,13 @@ kind:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   securityContext: {}
     # capabilities:
     #   drop:


### PR DESCRIPTION
Ideally, all users of the Konk CR would define right-size resources for konk's containers in their Konk spec, but I don't realistically expect this to happen. Reasonable default values, provided in this PR, will be much better than nothing for most cases, and can still be overridden in their CR as needed.

The apiserver and etcd requests in this PR are based on current measurements in a dev cluster. The init container resources are a guess because I couldn't figure out how to measure it (its lifetime is too short for kube-state-metrics to catch it).

An entirely alternative approach could be to use defaulting in the CRD to provide these defaults.
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting