### PR TITLE
Require konk and service name fields in KonkService

### DIFF
--- a/config/crd/bases/konk.infoblox.com_konkservices.yaml
+++ b/config/crd/bases/konk.infoblox.com_konkservices.yaml
@@ -33,6 +33,28 @@ spec:
             description: Spec defines the desired state of KonkService
             type: object
             x-kubernetes-preserve-unknown-fields: true
+            properties:
+              konk:
+                type: object
+                properties:
+                  name:
+                    description: The name of the konk to create the APIService in.
+                    type: string
+                required:
+                - name
+                x-kubernetes-preserve-unknown-fields: true
+              service:
+                type: object
+                properties:
+                  name:
+                    description: The name of your extension API service
+                    type: string
+                required:
+                - name
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+              - konk
+              - service
           status:
             description: Status defines the observed state of KonkService
             type: object

--- a/config/crd/bases/konk.infoblox.com_konkservices.yaml
+++ b/config/crd/bases/konk.infoblox.com_konkservices.yaml
@@ -34,6 +34,8 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
             properties:
+              group:
+                type: string
               konk:
                 type: object
                 properties:
@@ -52,9 +54,13 @@ spec:
                 required:
                 - name
                 x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
             required:
+              - group
               - konk
               - service
+              - version
           status:
             description: Status defines the observed state of KonkService
             type: object

--- a/config/crd/bases/konk.infoblox.com_konkservices.yaml
+++ b/config/crd/bases/konk.infoblox.com_konkservices.yaml
@@ -60,6 +60,16 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
+    additionalPrinterColumns:
+    - name: Konk
+      type: string
+      jsonPath: .spec.konk.name
+    - name: APIService
+      type: string
+      jsonPath: .spec.service.name
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
     served: true
     storage: true
     subresources:

--- a/examples/konk-service.yaml
+++ b/examples/konk-service.yaml
@@ -3,7 +3,9 @@ kind: KonkService
 metadata:
   name: example-konkservice
 spec:
+  group: example.infoblox.com
   konk:
     name: example-konk
   service:
     name: test
+  version: v1alpha1


### PR DESCRIPTION
This updates the KonkService CRD to require the konk.name and service.name fields.