### PR TITLE
Avoid bash warning when there are no CRDs to install

### DIFF
--- a/helm-charts/konk-service/templates/configmap.yaml
+++ b/helm-charts/konk-service/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
       fi
     done
     INSTALL=install
-    if [ $CRDS == $INSTALL ]
+    if [ "$CRDS" == "$INSTALL" ]
     then
       kubectl apply -f /mounts/
     fi


### PR DESCRIPTION
Fixes this error message:

    + INSTALL=install
    + '[' == install ']'
    /mounts/deploy-api-service.sh: line 18: [: ==: unary operator expected