### PR TITLE
add ingress

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,11 +24,13 @@ jobs:
           mkdir -p ~/.kube
           make helm-lint
       - uses: helm/kind-action@v1.0.0
+        with:
+          config: ./src/github.com/${{ github.repository }}/test/kind.yaml
       - name: Deploy charts
         timeout-minutes: 5
         run: |
           kubectl cluster-info
-          make deploy-cert-manager
+          make deploy-cert-manager deploy-ingress-nginx
       - name: Test konk-operator
         timeout-minutes: 6
         run: |
@@ -69,6 +71,14 @@ jobs:
             sleep 1
           done
           kubectl exec -it $POD_NAME -- kubectl get crd appconfigs.stable.example.com websites.extensions.example.com
+      - name: Test ingress
+        timeout-minutes: 1
+        run: |
+          kubectl -n ingress-nginx logs -l app.kubernetes.io/component=controller --tail 0 -f &
+          until kubectl -s localhost:80 get contacts
+          do
+            sleep 3
+          done
       - name: Print failure
         timeout-minutes: 1
         if: ${{ failure() }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,5 +84,5 @@ jobs:
         if: ${{ failure() }}
         run: |
           git diff
-          kubectl describe po
-          k get po,certificate,issuer,secrets,configmap
+          kubectl describe po,ing
+          kubectl get po,svc,ep,certificate,issuer,ingress,secrets,configmap

--- a/config/crd/bases/konk.infoblox.com_konkservices.yaml
+++ b/config/crd/bases/konk.infoblox.com_konkservices.yaml
@@ -51,6 +51,13 @@ spec:
                     type: array
                     items:
                       type: string
+              ingress:
+                type: object
+                properties:
+                  enabled:
+                    description: Creates an ingress resource pointing to the konk.
+                    type: boolean
+                x-kubernetes-preserve-unknown-fields: true
               konk:
                 type: object
                 properties:

--- a/helm-charts/example-apiserver/templates/konk-service.yaml
+++ b/helm-charts/example-apiserver/templates/konk-service.yaml
@@ -23,6 +23,8 @@ spec:
     - list
     - update
   version: v1alpha1
-  insecureSkipTLSVerify: {{ .Values.konkservice.insecureSkipTLSVerify }}
+  {{- with .Values.konkservice }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   crds: |
 {{ (.Files.Glob "crds/*").AsConfig | indent 4 }}

--- a/helm-charts/example-apiserver/values.yaml
+++ b/helm-charts/example-apiserver/values.yaml
@@ -109,6 +109,8 @@ kind:
     tag: v1.19.0
 
 konkservice:
+  ingress:
+    enabled: true
   insecureSkipTLSVerify: false
 
 konk:

--- a/helm-charts/konk-operator/templates/deployment.yaml
+++ b/helm-charts/konk-operator/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AUTH_URL
+              value: {{ .Values.authURL | default "" }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "konk-service.fullname" . }}
+{{- $konkName := printf "%s-konk" (.Values.konk.name | trimSuffix "-konk") }}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
@@ -17,8 +18,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: Authorization,Request-Id
   {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/proxy-ssl-name: {{ .Values.konk.name }}
-    nginx.ingress.kubernetes.io/proxy-ssl-secret: {{ .Values.konk.namespace | default .Release.Namespace }}/{{ .Values.konk.name }}-ingress-client
+    nginx.ingress.kubernetes.io/proxy-ssl-name: {{ $konkName }}
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: {{ .Values.konk.namespace | default .Release.Namespace }}/{{ $konkName }}-ingress-client
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
     # nginx.ingress.kubernetes.io/configuration-snippet: |
     #   proxy_set_header 'my-header' $var;
@@ -48,7 +49,7 @@ spec:
             # - /apis/example.infoblox.com/v1alpha1/namespaces/default/contacts
             # - /apis/{{ $.Values.group.name }}/{{ $.Values.version }}
             backend:
-              serviceName: {{ $.Values.konk.name }}-konk
+              serviceName: {{ $konkName }}
               servicePort: https
     {{- end }}
   {{- end }}

--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
             # - /apis/example.infoblox.com/v1alpha1/namespaces/default/contacts
             # - /apis/{{ $.Values.group.name }}/{{ $.Values.version }}
             backend:
-              serviceName: {{ $.Values.konk.name }}
+              serviceName: {{ $.Values.konk.name }}-konk
               servicePort: https
     {{- end }}
   {{- end }}

--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "konk-service.fullname" . }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konk-service.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ . }}
+    nginx.ingress.kubernetes.io/auth-response-headers: Authorization,Request-Id
+  {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: {{ .Values.konk.name }}
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: {{ .Values.konk.namespace | default .Release.Namespace }}/{{ .Values.konk.name }}-ingress-client
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+    # nginx.ingress.kubernetes.io/configuration-snippet: |
+    #   proxy_set_header 'my-header' $var;
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /api
+            # actual path examples:
+            # - /api
+            # - /apis
+            # - /apis/example.infoblox.com/v1alpha1/namespaces/default/contacts
+            # - /apis/{{ $.Values.group.name }}/{{ $.Values.version }}
+            backend:
+              serviceName: {{ $.Values.konk.name }}
+              servicePort: https
+    {{- end }}
+  {{- end }}

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -39,6 +39,17 @@ kind:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: localhost
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 konk:
   # The value below should be overriden by the konk-name
   name:

--- a/test/kind.yaml
+++ b/test/kind.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP

--- a/watches.yaml
+++ b/watches.yaml
@@ -7,4 +7,6 @@
   version: v1alpha1
   kind: KonkService
   chart: helm-charts/konk-service
+  overrideValues:
+    authURL: $AUTH_URL
 # +kubebuilder:scaffold:watch


### PR DESCRIPTION
Adds an `ingress` pointing to konk that supports proxied authentication.

Demo:
```
% kubectl -s localhost:80 get contacts
NAME              CREATED AT
contact-example   2020-11-02T21:43:03Z
```