### PR TITLE
Dump remote headers

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,7 +52,7 @@ jobs:
         timeout-minutes: 5
         run: |
           make kind-load-apiserver deploy-example-apiserver KIND_NAME="chart-testing"
-          POD_NAME=$(kubectl get pod -o name | grep konkservice)
+          POD_NAME=$(kubectl get pod -o name -l app.kubernetes.io/name=konk-service )
           until kubectl exec -it $POD_NAME -- kubectl get apiservice v1alpha1.example.infoblox.com | grep True
           do
             kubectl exec -it $POD_NAME -- kubectl describe apiservice v1alpha1.example.infoblox.com

--- a/helm-charts/example-apiserver/templates/apiservice-cr.yaml
+++ b/helm-charts/example-apiserver/templates/apiservice-cr.yaml
@@ -1,6 +1,0 @@
-# TODO: Install secrets with api-service
-# apiVersion:
-# kind: APIService
-# metadata:
-#   name: {{ include "example-apiserver.fullname" . }}
-# spec: {}

--- a/helm-charts/example-apiserver/templates/apiservice.yaml
+++ b/helm-charts/example-apiserver/templates/apiservice.yaml
@@ -39,7 +39,6 @@ spec:
   insecureSkipTLSVerify: true
 {{- end }}
 ---
-{{- end }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -51,3 +50,4 @@ metadata:
 data:
   tls.crt: {{ b64enc $aaCert.Cert }}
   tls.key: {{ b64enc $aaCert.Key }}
+{{- end }}

--- a/helm-charts/example-apiserver/templates/apiservice.yaml
+++ b/helm-charts/example-apiserver/templates/apiservice.yaml
@@ -16,7 +16,18 @@ metadata:
     apiserver: "true"
 spec:
   version: v1alpha1
-  group: example.infoblox.com
+  group:
+  - name: example.infoblox.com
+    kinds:
+    - Contact
+    verbs:
+    - create
+    - update
+    - get
+    - list
+    - delete
+    - patch
+    - watch
   groupPriorityMinimum: 2000
   service:
     name: {{ include "example-apiserver.fullname" . }}

--- a/helm-charts/example-apiserver/templates/deployment.yaml
+++ b/helm-charts/example-apiserver/templates/deployment.yaml
@@ -82,14 +82,18 @@ spec:
           - name: apiserver-certs
             mountPath: /apiserver.local.config/certificates
             readOnly: true
+          - name: kubeconfig
+            mountPath: /kubeconfig
+            readOnly: true
           command:
           - "./apiserver"
           args:
-          - "--delegated-auth=false"
+          - --authentication-kubeconfig=/kubeconfig/admin.conf
+          - --delegated-auth=false
           - --etcd-servers=http://127.0.0.1:{{ .Values.etcd.svc.port }}
-          - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
-          - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"
-          - "-v=10"
+          - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
+          - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
+          - -v=10
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -105,4 +109,7 @@ spec:
       volumes:
       - name: apiserver-certs
         secret:
-          secretName: {{ include "example-apiserver.fullname" . }}
+          secretName: {{ include "example-apiserver.fullname" . }}-diff-konk-service-server
+      - name: kubeconfig
+        secret:
+          secretName: {{ .Values.konk.name }}-kubeconfig

--- a/helm-charts/example-apiserver/templates/deployment.yaml
+++ b/helm-charts/example-apiserver/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
       volumes:
       - name: apiserver-certs
         secret:
-          secretName: {{ include "example-apiserver.fullname" . }}-diff-konk-service-server
+          secretName: {{ include "example-apiserver.fullname" . }}-api-konk-service-server
       - name: kubeconfig
         secret:
           secretName: {{ .Values.konk.name }}-kubeconfig

--- a/helm-charts/example-apiserver/templates/konk-service.yaml
+++ b/helm-charts/example-apiserver/templates/konk-service.yaml
@@ -1,7 +1,10 @@
 apiVersion: konk.infoblox.com/v1alpha1
 kind: KonkService
 metadata:
-  name: {{ include "example-apiserver.fullname" . }}-diff
+  name: {{ include "example-apiserver.fullname" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "example-apiserver.labels" . | nindent 4 }}
 spec:
   konk:
     name: {{ .Values.konk.name }}

--- a/helm-charts/example-apiserver/templates/konk-service.yaml
+++ b/helm-charts/example-apiserver/templates/konk-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: konk.infoblox.com/v1alpha1
 kind: KonkService
 metadata:
-  name: example-konkservice
+  name: {{ include "example-apiserver.fullname" . }}-diff
 spec:
   konk:
     name: {{ .Values.konk.name }}
@@ -20,6 +20,6 @@ spec:
     - list
     - update
   version: v1alpha1
-  insecureSkipTLSVerify: true
+  insecureSkipTLSVerify: {{ .Values.konkservice.insecureSkipTLSVerify }}
   crds: |
 {{ (.Files.Glob "crds/*").AsConfig | indent 4 }}

--- a/helm-charts/example-apiserver/values.yaml
+++ b/helm-charts/example-apiserver/values.yaml
@@ -103,5 +103,8 @@ apiserver:
     crt: ""
     key: ""
 
+konkservice:
+  insecureSkipTLSVerify: false
+
 konk:
   name: example-konk

--- a/helm-charts/konk-service/templates/deployment.yaml
+++ b/helm-charts/konk-service/templates/deployment.yaml
@@ -10,7 +10,6 @@ spec:
   selector:
     matchLabels:
       {{- include "konk-service.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: apiservice
   template:
     metadata:
       annotations:
@@ -18,7 +17,6 @@ spec:
         checksum/values: {{ print .Values | sha256sum }}
       labels:
         {{- include "konk-service.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: apiservice
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
       containers:

--- a/test/apiserver/cmd/apiserver/main.go
+++ b/test/apiserver/cmd/apiserver/main.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/go-openapi/loads"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	_ "github.com/infobloxopen/konk/test/apiserver/pkg/auth/remoteheader"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Enable cloud provider auth
 	"sigs.k8s.io/apiserver-builder-alpha/pkg/cmd/server"
 

--- a/test/apiserver/pkg/auth/remoteheader/remoteheader.go
+++ b/test/apiserver/pkg/auth/remoteheader/remoteheader.go
@@ -1,0 +1,60 @@
+package remoteheader
+
+import (
+	"net/http"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("remoteheader")
+
+func init() {
+	if err := restclient.RegisterAuthProviderPlugin("remoteheader", factory); err != nil {
+		klog.Fatalf("Failed to register oidc auth plugin: %v", err)
+	}
+}
+
+func factory(clusterAddress string, config map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+
+	return &provider{}, nil
+
+}
+
+type provider struct{}
+
+// WrapTransport allows the plugin to create a modified RoundTripper that
+// attaches authorization headers (or other info) to requests.
+func (p *provider) WrapTransport(h http.RoundTripper) http.RoundTripper {
+	return &roundTripper{
+		wrapped: h,
+	}
+}
+
+type roundTripper struct {
+	wrapped http.RoundTripper
+}
+
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	log.Info("dumping headers", "req.Header", req.Header)
+
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *req
+	// deep copy of the Header so we don't modify the original
+	// request's Header (as per RoundTripper contract).
+	r2.Header = make(http.Header)
+	for k, s := range req.Header {
+		r2.Header[k] = s
+	}
+
+	return r.wrapped.RoundTrip(req)
+}
+
+// Login allows the plugin to initialize its configuration. It must not
+// require direct user interaction.
+func (p *provider) Login() error {
+	return nil
+}


### PR DESCRIPTION
kube-apiserver to example-apiserver tls is now working. delegated auth is still not working and the auth plugin is not being executed

```
 k exec -it runner-example-apiserver-diff-konk-service-kubectl-9646678s6snm -- kubectl get apiservice v1alpha1.example.infoblox.com -o yaml | grep caBundle | wc -c
3330
➜  konk git:(dumpRemoteHeaders) k exec -it runner-example-apiserver-diff-konk-service-kubectl-9646678s6snm -- kubectl get contact
No resources found in default namespace.
```