### PR TITLE
eventually consistent APIService. Fixes ATLAS-8202

### DIFF
--- a/helm-charts/konk-service/templates/deployment.yaml
+++ b/helm-charts/konk-service/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         image: "{{ .Values.kind.image.repository }}:{{ .Values.kind.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.kind.image.pullPolicy }}
         command: ["/bin/bash", "-c"]
-        args: ["/mounts/deploy-api-service.sh; while true; do sleep 30; done;"]
+        args: ["while true; do /mounts/deploy-api-service.sh; date; sleep 30; done;"]
         env:
           - name: SERVICENAME
             value: {{ .Values.service.name }}


### PR DESCRIPTION
Konk's etcd data is not persistent, so after a konk pod restart we lose installed APIServices. This will reinstall them regularly.