### PR TITLE
Fix ingress routes

### DIFF
--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -42,7 +42,8 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /api
+        {{- range list "/api" "/apis" }}
+          - path: {{ . }}
             # actual path examples:
             # - /api
             # - /apis
@@ -51,5 +52,6 @@ spec:
             backend:
               serviceName: {{ $konkName }}
               servicePort: https
+        {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
I've no idea how the CI passed on #63, but it has been failing since merging #63 due to this path issue. Apparently when only `/api` is defined, `/apis` is not matched by the ingress, resulting in errors like `error: the server doesn't have a resource type "contacts"`:
https://github.com/infobloxopen/konk/pull/88/checks?check_run_id=1354101881#step:11:96