### PR TITLE
Workaround for proxy_ssl_name on ingress-nginx <0.31

### DIFF
--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -18,11 +18,15 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: Authorization,Request-Id
   {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/proxy-ssl-name: {{ $konkName }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      # workaround for ingress-nginx <0.31
+      # https://github.com/kubernetes/ingress-nginx/issues/4928#issuecomment-574331462
+      # https://github.com/kubernetes/ingress-nginx/commit/f9e410458c6cb4c243f301bdb5ffeed31bcc3f96
+      proxy_ssl_name "{{ $konkName }}";
+    # Enable to only support ingress-nginx >=0.31:
+    # nginx.ingress.kubernetes.io/proxy-ssl-name: {{ $konkName }}
     nginx.ingress.kubernetes.io/proxy-ssl-secret: {{ .Values.konk.namespace | default .Release.Namespace }}/{{ $konkName }}-ingress-client
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
-    # nginx.ingress.kubernetes.io/configuration-snippet: |
-    #   proxy_set_header 'my-header' $var;
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Konk uses TLS between nginx-ingress-controller and its apiserver. The nginx ingress annotation required to configure this TLS server name was not [added until 0.31](https://github.com/kubernetes/ingress-nginx/commit/f9e410458c6cb4c243f301bdb5ffeed31bcc3f96
). Versions earlier than this will report `502 Bad Gateway`.

This PR adds [a workaround](https://github.com/kubernetes/ingress-nginx/issues/4928#issuecomment-574331462
    ) to effectively make the same change to the nginx.conf.