### PR TITLE
Test upgrades

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,12 @@ jobs:
   end2end:
     name: End To End
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        isUpgrade: [true, false]
+        include:
+          - isUpgrade: true
+            ref: main
     timeout-minutes: 20
     defaults:
       run:
@@ -15,6 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./src/github.com/${{ github.repository }}
+          ref: ${{ matrix.ref }}
       - name: Fetch tags
         run: |
           pwd
@@ -31,13 +38,35 @@ jobs:
         run: |
           kubectl cluster-info
           make deploy-cert-manager deploy-ingress-nginx
-      - name: Test konk-operator
+      - name: Install konk-operator
+        if: ${{ matrix.isUpgrade }}
         timeout-minutes: 6
         run: |
           make kind-load-konk KIND_NAME="chart-testing"
           make deploy-konk-operator
 
           kubectl create -f examples/konk.yaml
+          until kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/name=konk
+          do
+            sleep 1
+          done
+      - name: Checkout code
+        if: ${{ matrix.isUpgrade }}
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
+      - name: Fetch tags
+        if: ${{ matrix.isUpgrade }}
+        run: |
+          pwd
+          git fetch --prune --unshallow
+      - name: Install/Upgrade konk-operator
+        timeout-minutes: 6
+        run: |
+          make kind-load-konk KIND_NAME="chart-testing"
+          make deploy-konk-operator
+
+          kubectl apply -f examples/konk.yaml
           until kubectl wait --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/name=konk
           do
             sleep 1


### PR DESCRIPTION
Uses a build matrix to test two end-to-end cases: upgrade and fresh install. In the upgrade case, konk-operator is first built and installed from `main`, then again from `HEAD`.

Upgrades have been our most common failure case because we haven't been testing it. The intent of this test is to identify upgrade-related failures before merging.

Docs: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy