### PR TITLE
build apiserver in docker

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           go-version: 1.15.x
       - name: Test Extension APIServer
-        timeout-minutes: 3
+        timeout-minutes: 7
         run: |
           # deploy example-apiserver using a passed KONK reference
           make deploy-apiserver KIND_NAME="chart-testing" KONK_NAME="runner-konk"

--- a/test/apiserver/Dockerfile
+++ b/test/apiserver/Dockerfile
@@ -1,4 +1,9 @@
-FROM infobloxcto/alpine_base:0.1.0 AS runner
+FROM golang:1.15 AS builder
+WORKDIR /go/src/github.com/infobloxopen/konk/test/apiserver
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/apiserver ./cmd/apiserver
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/controller-manager ./cmd/manager
 
-ADD apiserver .
-ADD controller-manager .
+FROM infobloxcto/alpine_base:0.1.0 AS runner
+COPY --from=builder /go/src/github.com/infobloxopen/konk/test/apiserver/bin/apiserver .
+COPY --from=builder /go/src/github.com/infobloxopen/konk/test/apiserver/bin/controller-manager .

--- a/test/apiserver/makefile
+++ b/test/apiserver/makefile
@@ -46,7 +46,7 @@ kind-load: image
 	$(KIND) load docker-image ${IMAGE} --name ${KIND_NAME}
 
 .image-${IMAGE_TAG}: build
-	docker build -t ${IMAGE} -f Dockerfile bin/
+	docker build --pull -t ${IMAGE} -f Dockerfile .
 	touch $@
 
 image: .image-${IMAGE_TAG}


### PR DESCRIPTION
This should resolve the error
```
% k -n konk-test logs thayward-apiserver-example-apiserver-7cf57df49-8nkcb -c example-apiserver
Error relocating ./apiserver: __vfprintf_chk: symbol not found
Error relocating ./apiserver: __fprintf_chk: symbol not found
```