### PR TITLE
cache go modules for faster build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,13 @@ jobs:
         with:
           path: ./src/github.com/${{ github.repository }}
           ref: ${{ matrix.ref }}
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Fetch tags
         run: |
           pwd

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,6 +29,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
       - name: Fetch tags
         run: |
           pwd

--- a/test/apiserver/Dockerfile
+++ b/test/apiserver/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:1.15 AS builder
 WORKDIR /go/src/github.com/infobloxopen/konk/test/apiserver
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/apiserver ./cmd/apiserver
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/controller-manager ./cmd/manager


### PR DESCRIPTION
https://github.com/actions/cache/blob/main/examples.md#go---modules

Also cache the intermediate layers of the docker build for faster builds.