### PR TITLE
Add troubleshooting section to readme and status field to kubectl get konks

### DIFF
--- a/config/crd/bases/konk.infoblox.com_konks.yaml
+++ b/config/crd/bases/konk.infoblox.com_konks.yaml
@@ -40,6 +40,13 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
+    additionalPrinterColumns:
+    - name: Status
+      type: string
+      jsonPath: .status.conditions[1].reason
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
Added troubleshooting section to readme.

Also added a status field to `kubectl get konks`. Demo:
```
% k get konks -A
NAMESPACE   NAME          STATUS              AGE
default     runner-konk   InstallSuccessful   20h
```