### PR TITLE
fix cache race

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ matrix.isUpgrade }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - uses: satackey/action-docker-layer-caching@v0.0.8


### PR DESCRIPTION
Should fix

    Unable to reserve cache with key Linux-go-2f61decb61d58b8f42e3320650d30cfd177b83378d5ab2f301b8bbda3ceaab8e, another job may be creating this cache.