### PR TITLE
Load existing CA

### DIFF
--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -xe
 
+# load existing CA
+if kubectl -n $NAMESPACE get secret $FULLNAME-ca
+then
+  mkdir -p /etc/kubernetes/pki
+  for ext in crt key
+  do
+    kubectl -n $NAMESPACE get secret $FULLNAME-ca -o 'go-template={{index .data "tls.'$ext'"}}' | base64 --decode > /etc/kubernetes/pki/ca.$ext
+  done
+fi
+
 kubeadm init phase certs all --apiserver-cert-extra-sans $FULLNAME,$FULLNAME.$NAMESPACE,$FULLNAME.$NAMESPACE.svc,$FULLNAME.$NAMESPACE.svc.cluster.local
 kubeadm init phase kubeconfig admin --control-plane-endpoint $FULLNAME.$NAMESPACE.svc
 find /etc/kubernetes/pki

--- a/helm-charts/konk/templates/init.yaml
+++ b/helm-charts/konk/templates/init.yaml
@@ -13,6 +13,8 @@ spec:
       app.kubernetes.io/component: init
   template:
     metadata:
+      annotations:
+        checksum/scripts: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "konk.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: init


### PR DESCRIPTION
Broken out from #101, this fix loads an existing CA secret before running `kubeadm`, so that certs generated by `kubeadm` are signed by the same original CA and trusted by all the user pods.