### PR TITLE
show latest status in status column

### DIFF
--- a/config/crd/bases/konk.infoblox.com_konks.yaml
+++ b/config/crd/bases/konk.infoblox.com_konks.yaml
@@ -43,7 +43,7 @@ spec:
     additionalPrinterColumns:
     - name: Status
       type: string
-      jsonPath: .status.conditions[1].reason
+      jsonPath: .status.conditions[-1].reason
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
The status column was always showing the second event. This is normally the current status, but in some cases there are three events and the second is not the latest. To show the current status, we should show the final condition, not the second.

# Demo

## All Conditions
```json
% k get konkservice thayward-apiserver-api -o jsonpath='{.status.conditions}' | jq                               kind-konk
[
  {
    "lastTransitionTime": "2020-11-10T00:57:35Z",
    "status": "True",
    "type": "Initialized"
  },
  {
    "lastTransitionTime": "2020-11-10T00:57:37Z",
    "reason": "InstallSuccessful",
    "status": "True",
    "type": "Deployed"
  },
  {
    "lastTransitionTime": "2020-11-12T21:35:19Z",
    "message": "failed to get candidate release: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0].args): invalid type for io.k8s.api.core.v1.Container.args: got \"string\", expected \"array\"",
    "reason": "ReconcileError",
    "status": "True",
    "type": "Irreconcilable"
  }
]
```

## Last Condition
```json
% k get konkservice thayward-apiserver-api -o jsonpath='{.status.conditions[-1]}' | jq                           kind-konk
{
  "lastTransitionTime": "2020-11-12T21:35:19Z",
  "message": "failed to get candidate release: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0].args): invalid type for io.k8s.api.core.v1.Container.args: got \"string\", expected \"array\"",
  "reason": "ReconcileError",
  "status": "True",
  "type": "Irreconcilable"
}
```