### PR TITLE
Allow unknown fields in CRD for future-proofing

### DIFF
--- a/config/crd/bases/konk.infoblox.com_konkservices.yaml
+++ b/config/crd/bases/konk.infoblox.com_konkservices.yaml
@@ -51,6 +51,7 @@ spec:
                     type: array
                     items:
                       type: string
+                x-kubernetes-preserve-unknown-fields: true
               ingress:
                 type: object
                 properties:
@@ -70,6 +71,7 @@ spec:
                     type: string
                 required:
                 - name
+                x-kubernetes-preserve-unknown-fields: true
               service:
                 type: object
                 properties:


### PR DESCRIPTION
With helm-operator, the `spec` of the CRD corresponds to values in a helm chart. Over the lifespan of a helm chart, it's typical to add support for new values. If we are to do this with the CRD, and not worry about the CRD upgrade being installed first, we need to allow unknown fields in the CRD spec.

The operator-sdk is aware of this issue and supplies the same option by default: https://github.com/operator-framework/operator-sdk/blob/eb694f23dff2cb9bd3af3df535c35fe5a534c444/internal/plugins/helm/v1/scaffolds/internal/templates/config/crd/crd.go#L108