### PR TITLE
propagate vault path

### DIFF
--- a/helm-charts/example-apiserver/templates/space.yaml
+++ b/helm-charts/example-apiserver/templates/space.yaml
@@ -11,11 +11,9 @@ metadata:
 spec:
   secretName: {{ template "example-apiserver.fullname" $ }}-{{ lower $key }}
   path: {{ tpl $secret.path $ }}
-  type: {{ tpl $secret.type $ }}
+  type: kubernetes.io/dockerconfigjson
   secrets:
-    {{- range $secret.keys }}
-    {{ . }}: VAULT
-    {{- end }}
+    config: VAULT
 ---
 {{- end }}
 {{- end }}

--- a/helm-charts/konk-operator/templates/deployment.yaml
+++ b/helm-charts/konk-operator/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: {{ (index .Values "cert-manager").namespace }}
             - name: SPACE
               value: {{ .Values.space.enabled | default "" | quote }}
+            - name: VAULT_PATH
+              value: {{ .Values.vaultCommon.imagepullsecret.path | default "" }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm-charts/konk-operator/values.yaml
+++ b/helm-charts/konk-operator/values.yaml
@@ -65,3 +65,9 @@ crds:
 
 dashboards:
   create: false
+
+vaultCommon:
+  imagepullsecret:
+    path:
+    keys: []
+    type: kubernetes.io/dockerconfigjson

--- a/helm-charts/konk-service/templates/space.yaml
+++ b/helm-charts/konk-service/templates/space.yaml
@@ -11,11 +11,9 @@ metadata:
 spec:
   secretName: {{ template "konk-service.fullname" $ }}-{{ lower $key }}
   path: {{ tpl $secret.path $ }}
-  type: {{ tpl $secret.type $ }}
+  type: kubernetes.io/dockerconfigjson
   secrets:
-    {{- range $secret.keys }}
-    {{ . }}: VAULT
-    {{- end }}
+    config: VAULT
 ---
 {{- end }}
 {{- end }}

--- a/helm-charts/konk/templates/space.yaml
+++ b/helm-charts/konk/templates/space.yaml
@@ -11,11 +11,9 @@ metadata:
 spec:
   secretName: {{ template "konk.fullname" $ }}-{{ lower $key }}
   path: {{ tpl $secret.path $ }}
-  type: {{ tpl $secret.type $ }}
+  type: kubernetes.io/dockerconfigjson
   secrets:
-    {{- range $secret.keys }}
-    {{ . }}: VAULT
-    {{- end }}
+    config: VAULT
 ---
 {{- end }}
 {{- end }}

--- a/watches.yaml
+++ b/watches.yaml
@@ -6,6 +6,7 @@
   overrideValues:
     certManager.namespace: $CERT_MANAGER_NAMESPACE
     space.enabled: $SPACE
+    vaultCommon.imagepullsecret.path: $VAULT_PATH
 - group: konk.infoblox.com
   version: v1alpha1
   kind: KonkService
@@ -13,6 +14,7 @@
   overrideValues:
     authURL: $AUTH_URL
     space.enabled: $SPACE
+    vaultCommon.imagepullsecret.path: $VAULT_PATH
 - group: konk.infoblox.com
   version: v1alpha1
   kind: Etcd


### PR DESCRIPTION
With `space: enabled`, `vaultCommon` must be propagated from the operator
to the konks, konkservices, and example-apiservers. However, `overrideValues`
only supports strings. The important part of `vaultCommon` is the path,
so I've hardcoded the parts other than the path. We're left with a single
string (path) that needs to be propagated.