### PR TITLE
support passing arbitrary values to etcd

### DIFF
--- a/helm-charts/konk/templates/etcd.yaml
+++ b/helm-charts/konk/templates/etcd.yaml
@@ -13,6 +13,7 @@ spec:
     rbac:
       enabled: false
     client:
+      enableAuthentication: true
       secureTransport: true
       existingSecret: {{ include "konk.fullname" $ }}-etcd-cert
       certFilename: server.crt
@@ -22,10 +23,5 @@ spec:
     imagePullSecrets:
       - {{ include "konk.fullname" $ }}-imagepullsecret
   {{- end }}
-  # these probes don't work with self-signed certs because probe.sh doesn't set the cacert path in the $AUTH_OPTIONS
-  livenessProbe:
-    enabled: false
-  readinessProbe:
-    enabled: false
 {{- end }}
 {{- end }}

--- a/helm-charts/konk/templates/etcd.yaml
+++ b/helm-charts/konk/templates/etcd.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "konk.labels" $ | nindent 4 }}
 spec:
+  {{ toYaml . | nindent 2 }}
   auth:
     rbac:
       enabled: false
@@ -26,7 +27,5 @@ spec:
     enabled: false
   readinessProbe:
     enabled: false
-  resources: {{ toYaml .resources | nindent 4 }}
-  statefulset: {{ toYaml .statefulset | nindent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Use carefully, since most fields of the statefulset are immutable:
```
failed upgrade (cannot patch \"runner-konk-etcd\" with kind StatefulSet: StatefulSet.apps \"runner-konk-etcd\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden)
```