### PR TITLE
drop Tiller support

### DIFF
--- a/config/crd/bases/konk.infoblox.com_konks.yaml
+++ b/config/crd/bases/konk.infoblox.com_konks.yaml
@@ -1,9 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    helm.sh/hook: crd-install
-    helm.sh/hook-delete-policy: before-hook-creation
   name: konks.konk.infoblox.com
 spec:
   group: konk.infoblox.com

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,10 +1,6 @@
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
-commonAnnotations:
-  helm.sh/hook: crd-install
-  # does not fail to install if resource already exists
-  helm.sh/hook-delete-policy: before-hook-creation
 resources:
 - bases/konk.infoblox.com_konks.yaml
 - bases/konk.infoblox.com_konkservices.yaml


### PR DESCRIPTION
`helm template --set=crds.create=true` with helm3 doesn't work with CRDs that have these `crd-install` hooks. Since `crd-install` was EOL with helm2, we can remove it.