### PR TITLE
Add a smoke test to konkservice

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -116,6 +116,7 @@ jobs:
           make test-apiserver
           # Test konkservice deployed
           make test-apiserver-konk-service
+          kubectl wait --timeout=1m --for=condition=ready pod -l app.kubernetes.io/name=konk-service,app.kubernetes.io/component=apiservice-test
       - name: Test ingress
         timeout-minutes: 1
         run: |

--- a/Makefile
+++ b/Makefile
@@ -248,3 +248,13 @@ upgrade-etcd:
 	cd $(CHART_DIR) && \
 	rm -rf etcd* && \
 	helm pull --debug --untar --repo https://charts.bitnami.com/bitnami etcd
+
+clean:
+	rm -rf \
+	.image-* \
+	.kind-load-* \
+	*.tgz \
+	bin/ \
+	helm-charts/konk-operator/crds/ \
+	helm-charts/konk-operator/rbac \
+	test/apiserver/.image-*

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "konk-service.fullname" . }}-kubectl-apiservice-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konk-service.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "konk-service.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: apiservice-test
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/apiservice-configmap.yaml") . | sha256sum }}
+        checksum/values: {{ print .Values | sha256sum }}
+      labels:
+        {{- include "konk-service.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: apiservice-test
+    spec:
+      serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      containers:
+      - name: kind
+        securityContext:
+          {{- toYaml .Values.kind.securityContext | nindent 10 }}
+        image: "{{ .Values.kind.image.repository }}:{{ .Values.kind.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.kind.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -x
+            while true
+            do
+              date
+              kubectl get apiservice {{ .Values.version }}.{{ .Values.group.name }} && \
+              kubectl api-resources --api-group={{ .Values.group.name }}
+              echo $? > /tmp/healthy
+              sleep $[ 30 + ( $RANDOM % 5 ) ]
+            done
+        env:
+          - name: KUBECONFIG
+            value: /etc/kubernetes/admin.conf
+        resources:
+          {{- toYaml .Values.kind.resources | nindent 10 }}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes"
+          readOnly: true
+        - name: tmp
+          mountPath: "/tmp"
+        readinessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "exit $(</tmp/healthy)"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: kubeconfig
+        secret:
+          secretName: {{ include "konk-service.fullname" . }}-kubeconfig
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
This new deployment is part of konkservice and periodically attempts to list resource types from the apiserver. If the apiserver doesn't respond properly, the pod indicates unready. This could be used in conjunction with tools like `kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=apiservice-test` for troubleshooting or kube-state-metrics for monitoring and alerting.