### PR TITLE
replace kubeconfig after cert changes. Fixes #192

### DIFF
--- a/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
@@ -13,6 +13,8 @@ spec:
   commonName: kubernetes-admin
   dnsNames:
   - admin
+  duration: 12h
+  renewBefore: 4h
   issuerRef:
     name: {{ .Values.konk.name }}-kubeadm-ca
     kind: {{ if eq .Values.konk.scope "cluster" }}Cluster{{ end }}Issuer

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               unset KUBECONFIG
               if [ "$(kubectl -n $NAMESPACE get secret {{ include "konk-service.fullname" . }}-kubeconfig --ignore-not-found 2>&1 )" = "" ]
               then
+              (
+                set -e
                 kubectl -n $NAMESPACE create secret generic {{ include "konk-service.fullname" . }}-kubeconfig \
                   --from-file=$KUBECONFIG_PATH
                 kubectl -n $NAMESPACE label secret {{ include "konk-service.fullname" . }}-kubeconfig $LABELS
@@ -58,8 +60,16 @@ spec:
                 DEPLOYMENT_UID=$(kubectl -n $NAMESPACE get deploy {{ include "konk-service.fullname" . }}-kubeconfig -o jsonpath='{.metadata.uid}')
                 echo "Found UID: $DEPLOYMENT_UID"
                 kubectl -n $NAMESPACE patch secret {{ include "konk-service.fullname" . }}-kubeconfig -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"{{ include "konk-service.fullname" . }}-kubeconfig", "uid":"'$DEPLOYMENT_UID'"}]}}'
-              else
-                echo TODO: kubectl patch to renew cert
+                md5sum /tmp/certs/* > /tmp/certsum
+              )
+              elif ! md5sum --status --check /tmp/certsum
+              then
+              (
+                set -e
+                kubectl -n $NAMESPACE create secret generic {{ include "konk-service.fullname" . }}-kubeconfig \
+                  --from-file=$KUBECONFIG_PATH --dry-run=client -o yaml | kubectl apply -f -
+                md5sum /tmp/certs/* > /tmp/certsum
+              )
               fi
               echo $? > /tmp/status
 


### PR DESCRIPTION
This change will cause the konk-service-kubeconfig secret to be rebuilt and replaced in the following conditions:
* on konk-service-kubeconfig pod startup (e.g., new konk service created or konk-operator upgraded)
* within 3 minutes of cert-manager renewing the kubeconfig cert