### PR TITLE
support Kubernetes v1.20+

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,12 @@ jobs:
         include:
           - isUpgrade: true
             ref: main
+        k8sVersion:
+          - v1.21.1
+          - v1.20.7
+          - v1.19.11
+          - v1.18.19
+          - v1.17.17
     timeout-minutes: 20
     defaults:
       run:
@@ -47,6 +53,8 @@ jobs:
         timeout-minutes: 5
         with:
           config: ./src/github.com/${{ github.repository }}/test/kind.yaml
+          node_image: kindest/node:${{ matrix.k8sVersion }}
+          version: v0.11.1
       - name: Deploy charts
         timeout-minutes: 2
         run: |

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -99,7 +99,3 @@ for name in $FULLNAME-apiserver-cert $FULLNAME-etcd-cert $FULLNAME-ca $FULLNAME-
 do
   kubectl patch -n $NAMESPACE secret $name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 done
-if [ "$SCOPE" = "cluster" ]
-then
-  kubectl patch -n $CERT_MANAGER_NAMESPACE secret $FULLNAME-ca -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "namespace":"'${NAMESPACE}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
-fi


### PR DESCRIPTION
Previously, the default kind version for kind-action v1.1.0 was used. This resolved to [kind v0.9.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0), which supported Kubernetes v1.13-v1.19. To test against v1.20, I've added an override to use [kind v0.11.1](https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1), which supports Kubernetes v1.14-v1.21. I've also added versions v1.17-v1.21 to the build matrix to cover all the environments we might deploy to.

Relevant error logs:
```
[kube-controller-manager] I0607 17:33:00.445314       1 event.go:291] "Event occurred" object="cert-manager/bulk-konk-ca" kind="Secret" apiVersion="v1" type="Warning" reason="OwnerRefInvalidNamespace" message="ownerRef [apps/v1/Deployment, namespace: cert-manager, name: bulk-konk, uid: ebf852d1-3c02-494d-9015-df03772fa6c5] does not exist in namespace \"cert-manager\""
[kube-controller-manager] I0607 17:33:00.448528       1 garbagecollector.go:580] "Deleting object" object="cert-manager/bulk-konk-ca" objectUID=f088ff5c-b6ba-46d0-9246-c920a0338df1 kind="Secret" propagationPolicy=Background
```

https://infoblox.atlassian.net/browse/ATLAS-10246