### PR TITLE
generate readmes for konk and konk-service charts/CRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -150,3 +150,15 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=konk-operator
           kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
           kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
+  readme:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: make chart-readmes
+      - name: commit changes
+        uses: EndBug/add-and-commit@v7
+        with:
+          message: update chart readme
+          add: helm-charts

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ KUBEADM		?= docker run --rm -it --entrypoint="" kindest/node:$(K8S_RELEASE) kube
 KUBECONFIG	?= ${HOME}/.kube/config
 RELEASE_PREFIX	?= $(USER)
 
+CHART_READMES   ?= $(foreach chart,konk konk-service,$(CHART_DIR)/$(chart)/README.md)
+HELM_DOCS       ?= docker run --rm \
+			-v $(shell pwd):/helm-docs \
+			-u $(shell id -u) \
+			jnorwood/helm-docs:latest
+
 # KIND env variables
 KIND_NAME   	?= konk
 NODE_VERSION    ?= v1.19.0
@@ -222,6 +228,13 @@ kind-load-apiserver: $(KIND) .image-apiserver-${GIT_VERSION}
 		KIND=$(KIND) KIND_NAME=${KIND_NAME} \
 		IMAGE_TAG=${GIT_VERSION} \
 		BUILD_FLAGS="-mod=readonly"
+
+
+.PHONY: $(CHART_READMES)
+$(CHART_READMES):
+	$(HELM_DOCS) -c $(@D) -t ../README.md.gotmpl
+
+chart-readmes: $(CHART_READMES)
 
 deploy-ingress-nginx:
 	# avoids accidentally deploying ingress controller in shared clusters

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ $(CHART_DIR)/konk/image-tag-values.yaml:
 helm-lint: helm-lint-$(notdir $(CHART_DIR)/*)
 
 helm-lint-%:
-	$(HELM) lint $(CHART_DIR)/$* --set=isLint=true
+	$(HELM) lint $(CHART_DIR)/$*/ --set=isLint=true
 
 # Run this only if your cluster does not have cert-manager already deployed
 deploy-cert-manager:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This chart will deploy konk.
 konk-operator is generated with operator-sdk and implements a helm operator for the konk chart and the konk-service chart. Once deployed, `Konk` and `KonkService` resources can be created in the cluster and the operator will deploy a konk instance and a konk-service instance for each of them.
 konk-operator applies the contents of the CR `.spec` as values in the respective helm chart.
 
-[`Konk` spec doc](helm-charts/konk/values.yaml)
+[`Konk` spec doc](helm-charts/konk/README.md)
 
 [Example `Konk` CR](examples/konk.yaml)
 
@@ -38,7 +38,7 @@ Found in [helm-charts/konk-service](helm-charts/konk-service).
 
 The konk-service chart or `KonkService` CR will deploy the resources required to register an `APIService` in konk. It requires an existing konk to be deployed in the cluster. You need to specify the name of the konk and the name of the service that the `APIService` object being created should point to. This would be specified under `konk.name` and `service.name` in the `values.yaml` file. Also specify the `group` and `version` values to be populated in the generated APIService.
 
-[`KonkService` spec doc](helm-charts/konk-service/values.yaml)
+[`KonkService` spec doc](helm-charts/konk-service/README.md)
 
 [Example `KonkService`](examples/konk-service.yaml)
 

--- a/helm-charts/README.md.gotmpl
+++ b/helm-charts/README.md.gotmpl
@@ -15,7 +15,7 @@
 {{ template "chart.requirementsSection" . }}
 
 {{ define "chart.valuesHeader" -}}
-## Values or `{{ .Name | title }}` `.spec`
+## Values or `{{ .Name | title | replace "-" "" }}` `.spec`
 
 When deploying with konk-operator, these configurations can be overridden in the `{{ .Name | title }}` `.spec`.
 

--- a/helm-charts/README.md.gotmpl
+++ b/helm-charts/README.md.gotmpl
@@ -1,0 +1,25 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ define "chart.valuesHeader" -}}
+## Values or `{{ .Name | title }}` `.spec`
+
+When deploying with konk-operator, these configurations can be overridden in the `{{ .Name | title }}` `.spec`.
+
+When deploying with `helm install`, these configurations are values and can be overridden in the [normal way](https://helm.sh/docs/helm/helm_install/#helm-install).
+{{ end }}
+
+{{ template "chart.valuesSection" . }}

--- a/helm-charts/konk-service/Chart.yaml
+++ b/helm-charts/konk-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: v1.19.0
-description: generates certificates for an konk-service
+description: Registers an aggregate API service in Konk
 name: konk-service
 type: application
 version: 0.1.0

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -4,7 +4,7 @@
 
 Registers an aggregate API service in Konk
 
-## Values or `Konk-Service` `.spec`
+## Values or `KonkService` `.spec`
 
 When deploying with konk-operator, these configurations can be overridden in the `Konk-Service` `.spec`.
 

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -15,16 +15,9 @@ When deploying with `helm install`, these configurations are values and can be o
 | annotations | object | `{}` | annotations to add to the APIService created in Konk by KonkService |
 | crds | string | `nil` |  |
 | fullnameOverride | string | `""` |  |
-| group.kinds[0] | string | `"Test"` |  |
-| group.kinds[1] | string | `"Alpha"` |  |
-| group.name | string | `"example.infoblox.com"` |  |
-| group.verbs[0] | string | `"create"` |  |
-| group.verbs[1] | string | `"update"` |  |
-| group.verbs[2] | string | `"get"` |  |
-| group.verbs[3] | string | `"list"` |  |
-| group.verbs[4] | string | `"delete"` |  |
-| group.verbs[5] | string | `"patch"` |  |
-| group.verbs[6] | string | `"watch"` |  |
+| group.kinds | list | `["*"]` | resource types provided by your API service. This list is used to setup default RBAC policies. |
+| group.name | string | `"example.infoblox.com"` | https://kubernetes.io/docs/reference/using-api/#api-groups |
+| group.verbs | list | `["*"]` | actions to allow on your API service. This list is used to setup default RBAC policies. |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"localhost"` |  |

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -1,0 +1,48 @@
+# konk-service
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0](https://img.shields.io/badge/AppVersion-v1.19.0-informational?style=flat-square)
+
+Registers an aggregate API service in Konk
+
+## Values or `Konk-Service` `.spec`
+
+When deploying with konk-operator, these configurations can be overridden in the `Konk-Service` `.spec`.
+
+When deploying with `helm install`, these configurations are values and can be overridden in the [normal way](https://helm.sh/docs/helm/helm_install/#helm-install).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| annotations | object | `{}` | annotations to add to the APIService created in Konk by KonkService |
+| crds | string | `nil` |  |
+| fullnameOverride | string | `""` |  |
+| group.kinds[0] | string | `"Test"` |  |
+| group.kinds[1] | string | `"Alpha"` |  |
+| group.name | string | `"example.infoblox.com"` |  |
+| group.verbs[0] | string | `"create"` |  |
+| group.verbs[1] | string | `"update"` |  |
+| group.verbs[2] | string | `"get"` |  |
+| group.verbs[3] | string | `"list"` |  |
+| group.verbs[4] | string | `"delete"` |  |
+| group.verbs[5] | string | `"patch"` |  |
+| group.verbs[6] | string | `"watch"` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"localhost"` |  |
+| ingress.tls | list | `[]` |  |
+| insecureSkipTLSVerify | bool | `false` |  |
+| kind.image.pullPolicy | string | `"Always"` |  |
+| kind.image.repository | string | `"kindest/node"` |  |
+| kind.image.tag | string | `"v1.19.0"` | Overrides the image tag whose default is the chart appVersion. |
+| kind.resources | object | `{}` |  |
+| kind.securityContext | object | `{}` |  |
+| konk.name | string | `""` | should be set to the konk-name |
+| konk.namespace | string | `""` |  |
+| konk.scope | string | `""` | scope of the konk, must match `.scope` of the Konk |
+| nameOverride | string | `""` |  |
+| service.caSecretName | string | `nil` | Optional reference to the secret the service's CA certs are stored in. When omitted, KonkService will generate a CA to be used by the APIService. |
+| service.name | string | `"test"` | Required to be set to the name of the service to be registered in Konk |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| space.enabled | bool | `false` |  |
+| version | string | `"v1alpha1"` |  |

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -74,18 +74,16 @@ service:
 crds: null
 
 group:
+  # -- https://kubernetes.io/docs/reference/using-api/#api-groups
   name: example.infoblox.com
+  # -- resource types provided by your API service.
+  # This list is used to setup default RBAC policies.
   kinds:
-  - Test
-  - Alpha
+  - "*"
+  # -- actions to allow on your API service.
+  # This list is used to setup default RBAC policies.
   verbs:
-  - create
-  - update
-  - get
-  - list
-  - delete
-  - patch
-  - watch
+  - "*"
 
 version: v1alpha1
 

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -17,14 +17,14 @@ serviceAccount:
 space:
   enabled: false
 
-# annotations to add to the APIService created in Konk by KonkService
+# -- annotations to add to the APIService created in Konk by KonkService
 annotations: {}
 
 kind:
   image:
     repository: kindest/node
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: v1.19.0
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -57,15 +57,17 @@ ingress:
   #      - chart-example.local
 
 konk:
-  # The value below should be overriden by the konk-name
+  # konk.name -- should be set to the konk-name
   name: ""
   namespace: ""
+  # -- scope of the konk, must match `.scope` of the Konk
+  #
   scope: ""
 
 service:
-  # The value below should be overriden by service-name
+  # -- Required to be set to the name of the service to be registered in Konk
   name: test
-  # Optional reference to the secret the service's CA certs are stored in.
+  # -- Optional reference to the secret the service's CA certs are stored in.
   # When omitted, KonkService will generate a CA to be used by the APIService.
   caSecretName:
 

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -1,0 +1,69 @@
+# konk
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0](https://img.shields.io/badge/AppVersion-v1.19.0-informational?style=flat-square)
+
+Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
+
+## Values or `Konk` `.spec`
+
+When deploying with konk-operator, these configurations can be overridden in the `Konk` `.spec`.
+
+When deploying with `helm install`, these configurations are values and can be overridden in the [normal way](https://helm.sh/docs/helm/helm_install/#helm-install).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| apiserver.disabledAPIs | list | `["apps/v1","apps/v1beta1","autoscaling/v1","autoscaling/v2beta1","autoscaling/v2beta2","batch/v1","batch/v1beta1","networking.k8s.io/v1","networking.k8s.io/v1beta1","storage.k8s.io/v1","storage.k8s.io/v1beta1"]` | specifies APIs unavailable in Konk. |
+| apiserver.extraFlags | object | `{}` |  |
+| apiserver.image.pullPolicy | string | `"Always"` |  |
+| apiserver.image.repository | string | `"k8s.gcr.io/kube-apiserver"` |  |
+| apiserver.image.tag | string | default is the chart appVersion. | Overrides the image tag |
+| apiserver.remoteHeaders.requestheader-extra-headers-prefix | string | `"X-Remote-Extra-"` |  |
+| apiserver.remoteHeaders.requestheader-group-headers | string | `"X-Remote-Group"` |  |
+| apiserver.remoteHeaders.requestheader-username-headers | string | `"X-Remote-User"` |  |
+| apiserver.resources.limits.cpu | string | `"200m"` |  |
+| apiserver.resources.limits.memory | string | `"512Mi"` |  |
+| apiserver.resources.requests.cpu | string | `"20m"` |  |
+| apiserver.resources.requests.memory | string | `"160Mi"` |  |
+| apiserver.securityContext | object | `{}` |  |
+| apiserver.startupProbe | bool | `true` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| certManager.namespace | string | `nil` |  |
+| etcd.operator | bool | `true` | defines how Konk's internal etcd is deployed. `true`: etcd is deployed by konk-operator `false`: etcd is deployed as a sidecar of konk's kube-apiserver |
+| etcd.resources.limits.cpu | string | `"200m"` |  |
+| etcd.resources.limits.memory | string | `"512Mi"` |  |
+| etcd.resources.requests.cpu | string | `"10m"` |  |
+| etcd.resources.requests.memory | string | `"64Mi"` |  |
+| etcd.securityContext | object | `{}` |  |
+| etcd.statefulset.replicaCount | int | `3` |  |
+| fullnameOverride | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"HTTPS"` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| kind.image.pullPolicy | string | `"Always"` |  |
+| kind.image.repository | string | `"kindest/node"` |  |
+| kind.image.tag | string | default is the chart appVersion. | Overrides the image tag |
+| kind.resources.limits.cpu | string | `"1000m"` |  |
+| kind.resources.limits.memory | string | `"512Mi"` |  |
+| kind.resources.requests.cpu | string | `"100m"` |  |
+| kind.resources.requests.memory | string | `"128Mi"` |  |
+| kind.securityContext | object | `{}` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| scope | string | `"namespace"` | scope can be `cluster` or `namespace`. When scope is `cluster`, Certificates in any namespace can be signed by the konk's Issuer. |
+| service.port | int | `6443` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| space.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -14,13 +14,13 @@ When deploying with `helm install`, these configurations are values and can be o
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | apiserver.disabledAPIs | list | `["apps/v1","apps/v1beta1","autoscaling/v1","autoscaling/v2beta1","autoscaling/v2beta2","batch/v1","batch/v1beta1","networking.k8s.io/v1","networking.k8s.io/v1beta1","storage.k8s.io/v1","storage.k8s.io/v1beta1"]` | specifies APIs unavailable in Konk. |
-| apiserver.extraFlags | object | `{}` |  |
+| apiserver.extraFlags | object | `{}` | additional command line flags for kube-apiserver. See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ for details. |
 | apiserver.image.pullPolicy | string | `"Always"` |  |
 | apiserver.image.repository | string | `"k8s.gcr.io/kube-apiserver"` |  |
 | apiserver.image.tag | string | default is the chart appVersion. | Overrides the image tag |
-| apiserver.remoteHeaders.requestheader-extra-headers-prefix | string | `"X-Remote-Extra-"` |  |
-| apiserver.remoteHeaders.requestheader-group-headers | string | `"X-Remote-Group"` |  |
-| apiserver.remoteHeaders.requestheader-username-headers | string | `"X-Remote-User"` |  |
+| apiserver.remoteHeaders.requestheader-extra-headers-prefix | string | `"X-Remote-Extra-"` | sets kube-apiserver's `--requestheader-extra-headers-prefix` option. See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ for details. |
+| apiserver.remoteHeaders.requestheader-group-headers | string | `"X-Remote-Group"` | sets kube-apiserver's `--requestheader-group-headers` option. |
+| apiserver.remoteHeaders.requestheader-username-headers | string | `"X-Remote-User"` | sets kube-apiserver's `--requestheader-username-headers` option. |
 | apiserver.resources.limits.cpu | string | `"200m"` |  |
 | apiserver.resources.limits.memory | string | `"512Mi"` |  |
 | apiserver.resources.requests.cpu | string | `"20m"` |  |

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -27,9 +27,15 @@ apiserver:
     # runAsUser: 1000
   startupProbe: true
   remoteHeaders:
+    # -- sets kube-apiserver's `--requestheader-extra-headers-prefix` option.
+    # See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ for details.
     requestheader-extra-headers-prefix: X-Remote-Extra-
+    # -- sets kube-apiserver's `--requestheader-group-headers` option.
     requestheader-group-headers: X-Remote-Group
+    # -- sets kube-apiserver's `--requestheader-username-headers` option.
     requestheader-username-headers: X-Remote-User
+  # -- additional command line flags for kube-apiserver.
+  # See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ for details.
   extraFlags: {}
   # -- specifies APIs unavailable in Konk.
   disabledAPIs:

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -8,7 +8,8 @@ apiserver:
   image:
     repository: k8s.gcr.io/kube-apiserver
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag
+    # @default -- default is the chart appVersion.
     tag: ""
   resources:
     limits:
@@ -30,6 +31,7 @@ apiserver:
     requestheader-group-headers: X-Remote-Group
     requestheader-username-headers: X-Remote-User
   extraFlags: {}
+  # -- specifies APIs unavailable in Konk.
   disabledAPIs:
     - apps/v1
     - apps/v1beta1
@@ -69,7 +71,9 @@ etcd:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  # etcd operator options
+  # -- defines how Konk's internal etcd is deployed.
+  # `true`: etcd is deployed by konk-operator
+  # `false`: etcd is deployed as a sidecar of konk's kube-apiserver
   operator: true
   statefulset:
     replicaCount: 3
@@ -78,7 +82,8 @@ kind:
   image:
     repository: kindest/node
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag
+    # @default -- default is the chart appVersion.
     tag: ""
   resources:
     limits:
@@ -99,8 +104,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# scope can be cluster or namespace.
-# When scope is cluster, Certificates in any namespace can be signed by the konk's Issuer.
+# -- scope can be `cluster` or `namespace`.
+# When scope is `cluster`, Certificates in any namespace can be signed by the konk's Issuer.
 scope: namespace
 
 serviceAccount:


### PR DESCRIPTION
`make chart-readmes` will now use the konk and konk-service values.yaml to generate a readme in markdown format to document the values. Uses https://github.com/norwoodj/helm-docs.