### PR TITLE
fix ci by using stable ingress-nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,11 +236,12 @@ $(CHART_READMES):
 
 chart-readmes: $(CHART_READMES)
 
+deploy-ingress-nginx: INGRESS_VERSION := $(shell curl -sS https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/stable.txt)
 deploy-ingress-nginx:
 	# avoids accidentally deploying ingress controller in shared clusters
 	kubectl config current-context | grep -v -E '(^[a-z]{3}-[0-9])|(infoblox.com$$)'
 	# https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx
-	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${INGRESS_VERSION}/deploy/static/provider/kind/deploy.yaml
 	until kubectl wait --namespace ingress-nginx \
 		--for=condition=ready pod \
 		--selector=app.kubernetes.io/component=controller \


### PR DESCRIPTION
Related ticket: https://github.com/kubernetes-sigs/kind/pull/2347

Note: upgrade test cases fail because they use the ingress-nginx version from `main`, which is unstable.