### PR TITLE
quote asterisk in resources and verbs

### DIFF
--- a/helm-charts/konk-service/templates/apiservice-configmap.yaml
+++ b/helm-charts/konk-service/templates/apiservice-configmap.yaml
@@ -79,11 +79,11 @@ data:
         - {{ .Values.group.name }}
         resources:
         {{- range .Values.group.kinds }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
         verbs:
         {{- range .Values.group.verbs }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
 {{ if .Values.crds }}
 {{ .Values.crds | indent 2 }}


### PR DESCRIPTION
https://github.com/infobloxopen/konk/commit/d1d5083efe0501aab4193344b6b761587ac215ab#diff-cc3c08c676cade00c3dbb66ef2f36bb4b95288f96bb70f9cfbefddcf4aa08650R82 made the default for `kinds` and `verbs` an `*`. In yaml, this must be quoted or we get errors like this:
```
+ kubectl apply -f /gen/api-service.yaml
namespace/hostapp unchanged
service/hostapp-aggregate-api-apiservice unchanged
apiservice.apiregistration.k8s.io/v1alpha1.onprem.bulk.infoblox.com unchanged
error: error parsing /gen/api-service.yaml: error converting YAML to JSON: yaml: line 12: did not find expected alphabetic or numeric character
```