### PR TITLE
add ingress-nginx version to the test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,10 @@ jobs:
         include:
           - isUpgrade: true
             ref: main
+          - ingressVersion: controller-v1.0.0
+            k8sVersion: v1.21.1
+        ingressVersion:
+          - controller-v0.49.0
         k8sVersion:
           - v1.21.1
           - v1.20.7
@@ -59,7 +63,7 @@ jobs:
         timeout-minutes: 2
         run: |
           kubectl cluster-info
-          make deploy-cert-manager deploy-ingress-nginx
+          make deploy-cert-manager deploy-ingress-nginx INGRESS_VERSION=${{ matrix.ingressVersion }}
       - name: Install konk-operator
         if: ${{ matrix.isUpgrade }}
         timeout-minutes: 6

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ $(CHART_READMES):
 
 chart-readmes: $(CHART_READMES)
 
-deploy-ingress-nginx: INGRESS_VERSION := $(shell curl -sS https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/stable.txt)
+deploy-ingress-nginx: INGRESS_VERSION := controller-v0.49.0
 deploy-ingress-nginx:
 	# avoids accidentally deploying ingress controller in shared clusters
 	kubectl config current-context | grep -v -E '(^[a-z]{3}-[0-9])|(infoblox.com$$)'

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ $(CHART_READMES):
 
 chart-readmes: $(CHART_READMES)
 
-deploy-ingress-nginx: INGRESS_VERSION := controller-v0.49.0
+deploy-ingress-nginx: INGRESS_VERSION := $(shell curl -sS https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/stable.txt)
 deploy-ingress-nginx:
 	# avoids accidentally deploying ingress controller in shared clusters
 	kubectl config current-context | grep -v -E '(^[a-z]{3}-[0-9])|(infoblox.com$$)'


### PR DESCRIPTION
Konk is [apparently incompatible](https://github.com/infobloxopen/konk/runs/3569079114?check_suite_focus=true) with ingress-nginx v1.0.0 (#233 might fix this). This PR pins the version used in the tests to one prior to the v1.0.0 release until Konk can be updated for v1.0.0 compatibility. It also adds v1.0.0 to the test matrix so we know when we've fixed it.