### PR TITLE
renew apiserver and etcd certs on konk pod startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docker-push:
 	docker push ${IMG}
 
 PATH  := $(PATH):$(shell pwd)/bin
-SHELL := env PATH=$(PATH) /bin/sh
+SHELL := env PATH="$(PATH)" /bin/sh
 OS    = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
 OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -41,30 +41,38 @@ kubeadm init phase certs etcd-server --config=/tmp/kubeadmcfg.yaml
 kubeadm init phase kubeconfig admin --control-plane-endpoint $FULLNAME.$NAMESPACE.svc
 find /etc/kubernetes/pki
 
-# replaces any existing etcd-cert
-if ! secret_not_found $FULLNAME-etcd-cert
+if secret_not_found $FULLNAME-etcd-cert
 then
-  kubectl -n $NAMESPACE delete secret $FULLNAME-etcd-cert
+  kubectl -n $NAMESPACE create secret generic $FULLNAME-etcd-cert \
+    --from-file=/etc/kubernetes/pki/etcd/ca.crt \
+    --from-file=/etc/kubernetes/pki/etcd/server.crt \
+    --from-file=/etc/kubernetes/pki/etcd/server.key
+  kubectl -n $NAMESPACE label secret $FULLNAME-etcd-cert $LABELS
+else
+  kubectl -n $NAMESPACE patch secret $FULLNAME-etcd-cert --type=json -p '[
+    {"op":"replace","path":"/data/server.crt","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/etcd/server.crt)"'"},
+    {"op":"replace","path":"/data/server.key","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/etcd/server.key)"'"}
+  ]'
 fi
-kubectl -n $NAMESPACE create secret generic $FULLNAME-etcd-cert \
-  --from-file=/etc/kubernetes/pki/etcd/ca.crt \
-  --from-file=/etc/kubernetes/pki/etcd/server.crt \
-  --from-file=/etc/kubernetes/pki/etcd/server.key
-kubectl -n $NAMESPACE label secret $FULLNAME-etcd-cert $LABELS
 
-# replaces any existing apiserver-cert
-if ! secret_not_found $FULLNAME-apiserver-cert
+if secret_not_found $FULLNAME-apiserver-cert
 then
-  kubectl -n $NAMESPACE delete secret $FULLNAME-apiserver-cert
+  kubectl -n $NAMESPACE create secret generic $FULLNAME-apiserver-cert \
+    --from-file=/etc/kubernetes/pki/apiserver.crt \
+    --from-file=/etc/kubernetes/pki/apiserver.key \
+    --from-file=/etc/kubernetes/pki/ca.crt \
+    --from-file=etcd-ca.crt=/etc/kubernetes/pki/etcd/ca.crt \
+    --from-file=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+    --from-file=/etc/kubernetes/pki/apiserver-etcd-client.key
+  kubectl -n $NAMESPACE label secret $FULLNAME-apiserver-cert $LABELS
+else
+  kubectl -n $NAMESPACE patch secret $FULLNAME-apiserver-cert --type=json -p '[
+    {"op":"replace","path":"/data/apiserver.crt","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/apiserver.crt)"'"},
+    {"op":"replace","path":"/data/apiserver.key","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/apiserver.key)"'"},
+    {"op":"replace","path":"/data/apiserver-etcd-client.crt","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/apiserver-etcd-client.crt)"'"},
+    {"op":"replace","path":"/data/apiserver-etcd-client.key","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/apiserver-etcd-client.key)"'"}
+  ]'
 fi
-kubectl -n $NAMESPACE create secret generic $FULLNAME-apiserver-cert \
-  --from-file=/etc/kubernetes/pki/apiserver.crt \
-  --from-file=/etc/kubernetes/pki/apiserver.key \
-  --from-file=/etc/kubernetes/pki/ca.crt \
-  --from-file=etcd-ca.crt=/etc/kubernetes/pki/etcd/ca.crt \
-  --from-file=/etc/kubernetes/pki/apiserver-etcd-client.crt \
-  --from-file=/etc/kubernetes/pki/apiserver-etcd-client.key
-kubectl -n $NAMESPACE label secret $FULLNAME-apiserver-cert $LABELS
 
 if secret_not_found $FULLNAME-ca
 then

--- a/helm-charts/konk/templates/init.yaml
+++ b/helm-charts/konk/templates/init.yaml
@@ -20,16 +20,25 @@ spec:
         app.kubernetes.io/component: init
     spec:
       serviceAccountName: {{ include "konk.serviceAccountName" . }}
-      initContainers:
-      - name: kind
+      containers:
+      - name: provision
         securityContext:
           {{- toYaml .Values.kind.securityContext | nindent 10 }}
         image: "{{ .Values.kind.image.repository }}:{{ .Values.kind.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.kind.image.pullPolicy }}
         command:
           - bash
+          - "-c"
         args:
-          - /scripts/provision.sh
+          - |
+            set -e
+            while true
+            do
+              date
+              /scripts/provision.sh
+              touch /tmp/ready
+              sleep 90d
+            done
         env:
           {{- with .Values.certManager.namespace }}
           - name: CERT_MANAGER_NAMESPACE
@@ -47,21 +56,17 @@ spec:
             value: {{ .Release.Name }}
           - name: SCOPE
             value: {{ .Values.scope }}
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
         resources:
           {{- toYaml .Values.kind.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /scripts/
           name: scripts
           readOnly: true
-      containers:
-      - name: done
-        securityContext:
-          {{- toYaml .Values.kind.securityContext | nindent 10 }}
-        image: "{{ .Values.kind.image.repository }}:{{ .Values.kind.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.kind.image.pullPolicy }}
-        command:
-          - sleep
-          - infinity
       volumes:
       - name: scripts
         configMap:


### PR DESCRIPTION
The etcd and apiserver certs generated by kubeadm are only valid for one year. Every time kubeadm runs, it will renew the certs, but before this change konk would never overwrite the existing certs with the new ones. This PR patches the existing certs with the freshly generated ones when the pod starts and every 90 days.

An alternative approach would be to redesign this process to use cert-manager (#303).