### PR TITLE
fix get secret

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,16 +12,17 @@ jobs:
         isUpgrade:
           - false
         k8sVersion:
-          - v1.23.0
-          - v1.22.4
-          - v1.21.2
-          - v1.20.7
+          - v1.26.0
+          - v1.25.3
+          - v1.24.7
+          - v1.23.13
+          - v1.22.15
         include:
           - isUpgrade: true
-            k8sVersion: v1.20.7
+            k8sVersion: v1.22.15
             ref: main
-          - ingressVersion: controller-v0.49.0
-            k8sVersion: v1.20.7
+          - ingressVersion: controller-v1.2.1
+            k8sVersion: v1.22.15
     timeout-minutes: 20
     defaults:
       run:

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -2,7 +2,7 @@
 set -xe
 
 secret_not_found () {
-  output=$(kubectl -n ${2:-$NAMESPACE} get secret $1 --ignore-not-found 2>&1 )
+  output=$(kubectl -n ${2:-$NAMESPACE} get secret $1 --ignore-not-found)
   echo "$output"
   [ "$output" = "" ]
 }


### PR DESCRIPTION
Info logs from kubectl output like `I0126 00:15:59.895033      10 request.go:645] Throttling request took 1.165292033s` were confusing the `secret_not_found` function. I'm not sure why this function was checking stderr in the first place. All we need is exit code 0 (from `set -e`) and empty stdout.