### PR TITLE
update cluster CA in case it has changed

### DIFF
--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -97,6 +97,11 @@ then
       --cert=/etc/kubernetes/pki/ca.crt \
       --key=/etc/kubernetes/pki/ca.key
     kubectl -n $CERT_MANAGER_NAMESPACE label secret $FULLNAME-ca $LABELS
+  else
+    kubectl -n $CERT_MANAGER_NAMESPACE patch secret $FULLNAME-ca --type=json -p '[
+      {"op":"replace","path":"/data/ca.crt","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/ca.crt)"'"},
+      {"op":"replace","path":"/data/ca.key","value":"'"$(base64 --wrap=0 < /etc/kubernetes/pki/ca.key)"'"},
+    ]'
   fi
 fi
 


### PR DESCRIPTION
In cases where the konk has been deleted and reinstalled, but a stale CA still exists in the cert-manager namespace, this will patch it with the latest CA. This allows ClusterIssuers to issue certs for the latest CA.

An alternative approach could be to read the value from the cert-manager namespace and use it to populate the konk namespace instead of replacing it.