### PR TITLE
fix kubeconfig renewal pod status reporting

### DIFF
--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -108,7 +108,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
+            - bash
             - -c
             - "exit $(</tmp/status)"
           initialDelaySeconds: 5


### PR DESCRIPTION
`sh` does not support the `$()` syntax, so this probe was always reporting healthy. Fixed by using `bash` instead, which supports the syntax used in the command.

```
% k -n ddi exec -it konk-service-kubeconfig-5dcb64tjzt -- sh -c 'exit $(</tmp/status)'
% echo $?
0

% k -n ddi exec -it konk-service-kubeconfig-5dcb64tjzt -- bash -c 'exit $(</tmp/status)'
error: Internal error occurred: error executing command in container: command terminated with exit code 137
% echo $?
1
```