### PR TITLE
increase default memory limits, remove cpu limits

### DIFF
--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -27,7 +27,9 @@ When deploying with `helm install`, these configurations are values and can be o
 | kind.image.pullPolicy | string | `"Always"` |  |
 | kind.image.repository | string | `"kindest/node"` |  |
 | kind.image.tag | string | `"v1.25.8"` | Overrides the image tag whose default is the chart appVersion. |
-| kind.resources | object | `{}` |  |
+| kind.resources.limits.memory | string | `"4Gi"` |  |
+| kind.resources.requests.cpu | string | `"10m"` |  |
+| kind.resources.requests.memory | string | `"40Mi"` |  |
 | kind.securityContext | object | `{}` |  |
 | konk.name | string | `""` | should be set to the konk-name |
 | konk.namespace | string | `""` |  |

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -26,17 +26,12 @@ kind:
     pullPolicy: Always
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: v1.25.8
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  resources:
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 10m
+      memory: 40Mi
   securityContext: {}
     # capabilities:
     #   drop:

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -21,8 +21,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | apiserver.remoteHeaders.requestheader-extra-headers-prefix | string | `"X-Remote-Extra-"` | sets kube-apiserver's `--requestheader-extra-headers-prefix` option. See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ for details. |
 | apiserver.remoteHeaders.requestheader-group-headers | string | `"X-Remote-Group"` | sets kube-apiserver's `--requestheader-group-headers` option. |
 | apiserver.remoteHeaders.requestheader-username-headers | string | `"X-Remote-User"` | sets kube-apiserver's `--requestheader-username-headers` option. |
-| apiserver.resources.limits.cpu | string | `"200m"` |  |
-| apiserver.resources.limits.memory | string | `"512Mi"` |  |
+| apiserver.resources.limits.memory | string | `"4Gi"` |  |
 | apiserver.resources.requests.cpu | string | `"20m"` |  |
 | apiserver.resources.requests.memory | string | `"160Mi"` |  |
 | apiserver.securityContext | object | `{}` |  |
@@ -33,8 +32,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | certManager.namespace | string | `nil` |  |
 | etcd.operator | bool | `true` | defines how Konk's internal etcd is deployed. `true`: etcd is deployed by konk-operator `false`: etcd is deployed as a sidecar of konk's kube-apiserver |
-| etcd.resources.limits.cpu | string | `"200m"` |  |
-| etcd.resources.limits.memory | string | `"512Mi"` |  |
+| etcd.resources.limits.memory | string | `"4Gi"` |  |
 | etcd.resources.requests.cpu | string | `"10m"` |  |
 | etcd.resources.requests.memory | string | `"64Mi"` |  |
 | etcd.securityContext | object | `{}` |  |
@@ -50,8 +48,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | kind.image.pullPolicy | string | `"Always"` |  |
 | kind.image.repository | string | `"kindest/node"` |  |
 | kind.image.tag | string | default is the chart appVersion. | Overrides the image tag |
-| kind.resources.limits.cpu | string | `"1000m"` |  |
-| kind.resources.limits.memory | string | `"512Mi"` |  |
+| kind.resources.limits.memory | string | `"4Gi"` |  |
 | kind.resources.requests.cpu | string | `"100m"` |  |
 | kind.resources.requests.memory | string | `"128Mi"` |  |
 | kind.securityContext | object | `{}` |  |

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -13,8 +13,7 @@ apiserver:
     tag: ""
   resources:
     limits:
-      cpu: 200m
-      memory: 512Mi
+      memory: 4Gi
     requests:
       cpu: 20m
       memory: 160Mi
@@ -64,8 +63,7 @@ etcd:
   #   tag: "3.4.9-1" # keep image versions in sync with `kubeadm config images list`
   resources:
     limits:
-      cpu: 200m
-      memory: 512Mi
+      memory: 4Gi
     requests:
       cpu: 10m
       memory: 64Mi
@@ -93,8 +91,7 @@ kind:
     tag: ""
   resources:
     limits:
-      cpu: 1000m
-      memory: 512Mi
+      memory: 4Gi
     requests:
       cpu: 100m
       memory: 128Mi


### PR DESCRIPTION
Memory limits should be much higher than anticipated usage. CPU limits are optional, so removed from defaults.

Added defaults to konk-service pods. Closes #240.