### PR TITLE
check etcd in konk readiness

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
             echo "::group::$cmd"
             $cmd
             echo "::endgroup::"
-          done <<< 'git diff
+          done <<< "git diff
           helm list --all-namespaces
           kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
           kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
@@ -168,7 +168,7 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=konk-operator
           kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
           kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
-          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx'
+          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
       - name: Test delete
         timeout-minutes: 3
         run: |
@@ -184,7 +184,7 @@ jobs:
             echo "::group::$cmd"
             $cmd
             echo "::endgroup::"
-          done <<< 'git diff
+          done <<< "git diff
           helm list --all-namespaces
           kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
           kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
@@ -192,7 +192,7 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=konk-operator
           kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
           kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
-          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx'
+          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
   readme:
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,6 +31,23 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
       KONK_NAMESPACE: baz
+      PRINT_DEBUG: |
+        set +x
+        while read cmd
+        do
+          echo "::group::$cmd"
+          $cmd
+          echo "::endgroup::"
+        done <<< "git diff
+        helm list --all-namespaces
+        kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
+        kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
+        kubectl logs -l app.kubernetes.io/name=etcd -n $KONK_NAMESPACE
+        kubectl logs -l app.kubernetes.io/component=apiserver -n $KONK_NAMESPACE
+        kubectl logs -l app.kubernetes.io/name=konk-operator
+        kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
+        kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
+        kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -153,22 +170,7 @@ jobs:
           done
       - name: Print debug
         if: ${{ always() }}
-        run: |
-          set +x
-          while read cmd
-          do
-            echo "::group::$cmd"
-            $cmd
-            echo "::endgroup::"
-          done <<< "git diff
-          helm list --all-namespaces
-          kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
-          kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
-          kubectl logs -l app.kubernetes.io/component=apiservice -n $KONK_NAMESPACE
-          kubectl logs -l app.kubernetes.io/name=konk-operator
-          kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
-          kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
-          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
+        run: bash -c "$PRINT_DEBUG"
       - name: Test delete
         timeout-minutes: 3
         run: |
@@ -177,22 +179,7 @@ jobs:
           [ -z "$(helm list --all-namespaces --filter '^runner-.*konk(-service)?$' | tee /dev/stderr | grep konk)" ]
       - name: Print debug
         if: ${{ always() }}
-        run: |
-          set +x
-          while read cmd
-          do
-            echo "::group::$cmd"
-            $cmd
-            echo "::endgroup::"
-          done <<< "git diff
-          helm list --all-namespaces
-          kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
-          kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
-          kubectl logs -l app.kubernetes.io/component=apiserver -n $KONK_NAMESPACE
-          kubectl logs -l app.kubernetes.io/name=konk-operator
-          kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
-          kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
-          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
+        run: bash -c "$PRINT_DEBUG"
   readme:
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,8 +45,8 @@ jobs:
         kubectl logs -l app.kubernetes.io/name=etcd -n $KONK_NAMESPACE
         kubectl logs -l app.kubernetes.io/component=apiserver -n $KONK_NAMESPACE
         kubectl logs -l app.kubernetes.io/name=konk-operator
-        kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
-        kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
+        kubectl logs -l app.kubernetes.io/component=controller,app.kubernetes.io/name=example-apiserver
+        kubectl logs -l app.kubernetes.io/component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
         kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx"
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -106,6 +106,10 @@ jobs:
           kubectl create ns $KONK_NAMESPACE || true
           kubectl apply -n $KONK_NAMESPACE -f examples/konk.yaml
           # FIXME: use the helm-operator status to detect installation was successful
+          until kubectl wait -n $KONK_NAMESPACE --timeout=3m --for=condition=ready pod -l app.kubernetes.io/name=etcd
+          do
+            sleep 1
+          done
           until kubectl wait -n $KONK_NAMESPACE --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/name=konk
           do
             sleep 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -147,6 +147,24 @@ jobs:
           do
             sleep 3
           done
+      - name: Print debug
+        if: ${{ always() }}
+        run: |
+          set +x
+          while read cmd
+          do
+            echo "::group::$cmd"
+            $cmd
+            echo "::endgroup::"
+          done <<< 'git diff
+          helm list --all-namespaces
+          kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
+          kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
+          kubectl logs -l app.kubernetes.io/component=apiservice -n $KONK_NAMESPACE
+          kubectl logs -l app.kubernetes.io/name=konk-operator
+          kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
+          kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver
+          kubectl logs -l app.kubernetes.io/component=controller -n ingress-nginx'
       - name: Test delete
         timeout-minutes: 3
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -188,7 +188,7 @@ jobs:
           helm list --all-namespaces
           kubectl describe po,ing,certificate,clusterissuer,issuer,konk,konkservice -A
           kubectl get po,rs,svc,ep,certificate,clusterissuer,issuer,ingress,secrets,configmap -A
-          kubectl logs -l app.kubernetes.io/component=apiservice -n $KONK_NAMESPACE
+          kubectl logs -l app.kubernetes.io/component=apiserver -n $KONK_NAMESPACE
           kubectl logs -l app.kubernetes.io/name=konk-operator
           kubectl logs -l component=controller,app.kubernetes.io/name=example-apiserver
           kubectl logs -l component=apiserver,app.kubernetes.io/name=example-apiserver -c example-apiserver

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CHART_DIR	:= helm-charts
 GIT_VERSION	?= $(shell git describe --dirty=-unsupported --always --long --tags)
-HELM_IMAGE	?= infoblox/helm:3.2.4-5b243a2
+HELM_IMAGE	?= infoblox/helm:3
 DOCKER_RUNNER	?= docker run --rm -i \
 			--entrypoint="" \
 			--network host \

--- a/helm-charts/example-apiserver/templates/deployment-controller.yaml
+++ b/helm-charts/example-apiserver/templates/deployment-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "example-apiserver.labels" . | nindent 4 }}
-    component: controller
+    app.kubernetes.io/component: controller
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "example-apiserver.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -21,6 +22,7 @@ spec:
     {{- end }}
       labels:
         {{- include "example-apiserver.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-charts/example-apiserver/templates/deployment.yaml
+++ b/helm-charts/example-apiserver/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "example-apiserver.labels" . | nindent 4 }}
-    component: apiserver
+    app.kubernetes.io/component: apiserver
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm-charts/konk/templates/deployment.yaml
+++ b/helm-charts/konk/templates/deployment.yaml
@@ -70,19 +70,19 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: https
               scheme: HTTPS
             initialDelaySeconds: 120
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: '/readyz?exclude=informer-sync'
               port: https
               scheme: HTTPS
           {{- if .Values.apiserver.startupProbe }}
           startupProbe:
             httpGet:
-              path: /healthz
+              path: '/readyz?exclude=informer-sync'
               port: https
               scheme: HTTPS
             failureThreshold: 30


### PR DESCRIPTION
Previously we were only testing the konk apiserver for liveness. This changes it to use the readiness check, which checks a number of things including the etcd connection. See https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health

Also cleaned up a bunch of things in the CI to support testing this.