### PR TITLE
Truncate the delete apiservice job name

### DIFF
--- a/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "konk-service.fullname" . }}-delete-apiservice
+  name: {{ include "konk-service.fullname" . | trunc 43 }}-delete-apiservice
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}

--- a/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "konk-service.fullname" . | trunc 43 }}-delete-apiservice
+  name: {{ include "konk-service.fullname" . | trunc 43 | trimSuffix "-" }}-delete-apiservice
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}


### PR DESCRIPTION
Observed an error where a long konk-service release name could potentially prevent a delete-apiservice job from triggering as it would surpass the 63 character limit allowed for job names. This PR resolves this by truncating the length of the job name to less than 63 characters.