### PR TITLE
PTCI-3294: Fix vulns update node v1.25.8 to v1.35.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ HELM		?= $(DOCKER_RUNNER) \
 			helm
 HELM_CMD	?= $(DOCKER_RUNNER) \
 			/bin/bash -c
-K8S_RELEASE	?= v1.25.8
+K8S_RELEASE	?= v1.35.0
 KUBEADM		?= docker run --rm -it --entrypoint="" kindest/node:$(K8S_RELEASE) kubeadm
 KUBECONFIG	?= ${HOME}/.kube/config
 RELEASE_PREFIX	?= $(USER)
@@ -26,7 +26,7 @@ HELM_DOCS       ?= docker run --rm \
 
 # KIND env variables
 KIND_NAME   	?= konk
-NODE_VERSION    ?= v1.25.8
+NODE_VERSION    ?= v1.35.0
 NODE_IMAGE      ?= kindest/node:${NODE_VERSION}
 KIND_VERSION    ?= v0.18.0
 KIND 			:= $(shell pwd)/bin/kind

--- a/helm-charts/example-apiserver/values.yaml
+++ b/helm-charts/example-apiserver/values.yaml
@@ -110,7 +110,7 @@ kind:
   image:
     repository: kindest/node
     pullPolicy: Always
-    tag: v1.25.8
+    tag: v1.35.0
 
 konkservice:
   ingress:

--- a/helm-charts/konk-service/Chart.yaml
+++ b/helm-charts/konk-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25.8
+appVersion: v1.35.0
 description: Registers an aggregate API service in Konk
 name: konk-service
 type: application

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -1,6 +1,6 @@
 # konk-service
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Registers an aggregate API service in Konk
 
@@ -26,7 +26,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | insecureSkipTLSVerify | bool | `false` |  |
 | kind.image.pullPolicy | string | `"Always"` |  |
 | kind.image.repository | string | `"kindest/node"` |  |
-| kind.image.tag | string | `"v1.25.8"` | Overrides the image tag whose default is the chart appVersion. |
+| kind.image.tag | string | `"v1.35.0"` | Overrides the image tag whose default is the chart appVersion. |
 | kind.resources.limits.memory | string | `"4Gi"` |  |
 | kind.resources.requests.cpu | string | `"10m"` |  |
 | kind.resources.requests.memory | string | `"40Mi"` |  |

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -25,7 +25,7 @@ kind:
     repository: kindest/node
     pullPolicy: Always
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: v1.25.8
+    tag: v1.35.0
   resources:
     limits:
       memory: 4Gi

--- a/helm-charts/konk/Chart.yaml
+++ b/helm-charts/konk/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25.8
+appVersion: v1.35.0
 description: Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 name: konk
 type: application

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -1,6 +1,6 @@
 # konk
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 

--- a/helm-charts/konk/image-tag-values.yaml
+++ b/helm-charts/konk/image-tag-values.yaml
@@ -1,7 +1,7 @@
-# kubernetes v1.25.8
+# kubernetes v1.35.0
 apiserver:
   image:
-    tag: v1.25.8
+    tag: v1.35.0
 etcd:
   image:
     tag: 3.4.9-1


### PR DESCRIPTION
- Update Kubernetes version from v1.25.8 to v1.35.0
- Update kindest/node image tag to v1.35.0 across all charts
- Update K8S_RELEASE and NODE_VERSION in Makefile
- Update appVersion in konk and konk-service charts
- Regenerate chart README files with helm-docs