### PR TITLE
fix: push new distroless images in CI and load correct tags in operator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,9 @@ pipeline {
             sudo apt-get update
             sudo apt-get install -y golang-go
             make docker-build docker-push
+            make docker-build-kubernetes docker-push-kubernetes
+            make docker-build-provision docker-push-provision
+            make docker-build-konk-service docker-push-konk-service
             make -C test/apiserver push
           '''
         }

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,7 @@ default: all
 
 .PHONY: $(CHART_DIR)/konk/image-tag-values.yaml
 $(CHART_DIR)/konk/image-tag-values.yaml:
-	@IMAGES=`$(KUBEADM) config images list` && \
-	ETCD_VERSION=`echo "$$IMAGES" | grep etcd | cut -d: -f2` && \
-	echo "# kubernetes $(K8S_RELEASE)\napiserver:\n  image:\n    tag: $(K8S_RELEASE)-$(GIT_SHORT)\netcd:\n  image:\n    tag: $$ETCD_VERSION\nprovision:\n  image:\n    tag: $(GIT_VERSION)" | tee $@
+	@printf "# kubernetes $(K8S_RELEASE)\napiserver:\n  image:\n    tag: $(K8S_RELEASE)-$(GIT_SHORT)\nprovision:\n  image:\n    tag: $(GIT_VERSION)\nkind:\n  image:\n    tag: $(GIT_VERSION)\n" | tee $@
 
 CHART_NAMES := $(shell find $(CHART_DIR) -maxdepth 1 -type d | grep -v '^$(CHART_DIR)$$' | xargs -I {} basename {})
 
@@ -135,7 +133,7 @@ deploy: kustomize
 undeploy: kustomize
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
-.image-${GIT_VERSION}:
+.image-${GIT_VERSION}: $(CHART_DIR)/konk/image-tag-values.yaml
 	DOCKER_BUILDKIT=1 docker build . -t ${IMG}
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ HELM		?= $(DOCKER_RUNNER) \
 HELM_CMD	?= $(DOCKER_RUNNER) \
 			/bin/bash -c
 K8S_RELEASE	?= v1.25.8
+ETCD_VERSION	?= v3.6.8
 KUBEADM		?= docker run --rm -it --entrypoint="" ${KUBERNETES_IMG} kubeadm
 KUBECONFIG	?= ${HOME}/.kube/config
 RELEASE_PREFIX	?= $(USER)
@@ -36,7 +37,7 @@ default: all
 
 .PHONY: $(CHART_DIR)/konk/image-tag-values.yaml
 $(CHART_DIR)/konk/image-tag-values.yaml:
-	@printf "# kubernetes $(K8S_RELEASE)\napiserver:\n  image:\n    tag: $(K8S_RELEASE)-$(GIT_SHORT)\nprovision:\n  image:\n    tag: $(GIT_VERSION)\nkind:\n  image:\n    tag: $(GIT_VERSION)\n" | tee $@
+	@printf "# kubernetes $(K8S_RELEASE)\napiserver:\n  image:\n    tag: $(K8S_RELEASE)-$(GIT_SHORT)\netcd:\n  image:\n    tag: $(ETCD_VERSION)\nprovision:\n  image:\n    tag: $(GIT_VERSION)\nkind:\n  image:\n    tag: $(GIT_VERSION)\n" | tee $@
 
 CHART_NAMES := $(shell find $(CHART_DIR) -maxdepth 1 -type d | grep -v '^$(CHART_DIR)$$' | xargs -I {} basename {})
 

--- a/helm-charts/konk/image-tag-values.yaml
+++ b/helm-charts/konk/image-tag-values.yaml
@@ -1,13 +1,13 @@
-# kubernetes v1.25.8
+# kubernetes $(K8S_RELEASE)
 apiserver:
   image:
-    tag: v1.25.8-g9fefaa7
+    tag: $(K8S_RELEASE)-$(GIT_SHORT)
 etcd:
   image:
-    tag: v3.6.8
+    tag: $(ETCD_VERSION)
 provision:
   image:
-    tag: v0.2.1-150-g9fefaa7-j11
+    tag: $(GIT_VERSION)
 kind:
   image:
-    tag: v0.2.1-150-g9fefaa7-j11
+    tag: $(GIT_VERSION)

--- a/helm-charts/konk/image-tag-values.yaml
+++ b/helm-charts/konk/image-tag-values.yaml
@@ -1,7 +1,13 @@
 # kubernetes v1.25.8
 apiserver:
   image:
-    tag: v1.25.8
+    tag: v1.25.8-g9fefaa7
 etcd:
   image:
-    tag: 3.4.9-1
+    tag: v3.6.8
+provision:
+  image:
+    tag: v0.2.1-150-g9fefaa7-j11
+kind:
+  image:
+    tag: v0.2.1-150-g9fefaa7-j11

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,6 +3,8 @@
   version: v1alpha1
   kind: Konk
   chart: helm-charts/konk
+  valuesFiles:
+    - helm-charts/konk/image-tag-values.yaml
   overrideValues:
     certManager.namespace: $CERT_MANAGER_NAMESPACE
     space.enabled: $SPACE


### PR DESCRIPTION
- Jenkinsfile: add docker-build/push targets for konk-app, konk-provision, and konk-service — these images were never pushed by CI after being introduced in #582
- Makefile: simplify image-tag-values.yaml generation (remove kubeadm dependency, add kind.image.tag); make docker-build depend on it so tags are always regenerated before baking into the operator image
- watches.yaml: add valuesFiles for image-tag-values.yaml so operator loads correct image tags at runtime instead of falling back to appVersion
- image-tag-values.yaml: update bootstrap tags for current build