### PR TITLE
fix: push images to GHCR instead of Docker Hub

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -1,0 +1,40 @@
+name: Build and push images to GHCR
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+    - name: Log in to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.IBOPEN_GHCR_GITHUB_TOKEN }}
+    - name: Build Images
+      env:
+        BUILDKIT_PROGRESS: plain
+      run: |
+        make docker-build
+        make docker-build-kubernetes
+        make docker-build-provision
+        make docker-build-konk-service
+    - name: Push Images to GHCR
+      env:
+        BUILDKIT_PROGRESS: plain
+      run: |
+        make docker-push
+        make docker-push-kubernetes
+        make docker-push-provision
+        make docker-push-konk-service

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,13 +33,6 @@ pipeline {
       steps {
         withDockerRegistry([credentialsId: "dockerhub-bloxcicd", url: ""]) {
           sh '''
-            sudo add-apt-repository ppa:longsleep/golang-backports
-            sudo apt-get update
-            sudo apt-get install -y golang-go
-            make docker-build docker-push
-            make docker-build-kubernetes docker-push-kubernetes
-            make docker-build-provision docker-push-provision
-            make docker-build-konk-service docker-push-konk-service
             make -C test/apiserver push
           '''
         }

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= infoblox/konk:$(GIT_VERSION)
-PROVISION_IMG ?= infoblox/konk-provision:$(GIT_VERSION)
-KONK_SERVICE_IMG ?= infoblox/konk-service:$(GIT_VERSION)
+IMG ?= ghcr.io/infobloxopen/konk:$(GIT_VERSION)
+PROVISION_IMG ?= ghcr.io/infobloxopen/konk-provision:$(GIT_VERSION)
+KONK_SERVICE_IMG ?= ghcr.io/infobloxopen/konk-service:$(GIT_VERSION)
 GIT_SHORT ?= g$(shell git rev-parse --short HEAD)
-KUBERNETES_IMG ?= infoblox/konk-app:$(K8S_RELEASE)-$(GIT_SHORT)
+KUBERNETES_IMG ?= ghcr.io/infobloxopen/konk-app:$(K8S_RELEASE)-$(GIT_SHORT)
 
 all: docker-build
 
@@ -271,12 +271,12 @@ kind-destroy: $(KIND)
 
 kind-load-konk: $(KIND) docker-build docker-build-kubernetes docker-build-provision docker-build-konk-service
 	@# Tag images with the chart appVersion so the operator's embedded chart can find them
-	docker tag ${KUBERNETES_IMG} infoblox/konk-app:$(K8S_RELEASE)
-	docker tag ${PROVISION_IMG} infoblox/konk-provision:$(K8S_RELEASE)
-	docker tag ${KONK_SERVICE_IMG} infoblox/konk-service:$(K8S_RELEASE)
+	docker tag ${KUBERNETES_IMG} ghcr.io/infobloxopen/konk-app:$(K8S_RELEASE)
+	docker tag ${PROVISION_IMG} ghcr.io/infobloxopen/konk-provision:$(K8S_RELEASE)
+	docker tag ${KONK_SERVICE_IMG} ghcr.io/infobloxopen/konk-service:$(K8S_RELEASE)
 	$(KIND) load docker-image ${IMG} ${KUBERNETES_IMG} ${PROVISION_IMG} ${KONK_SERVICE_IMG} \
-		infoblox/konk-app:$(K8S_RELEASE) infoblox/konk-provision:$(K8S_RELEASE) \
-		infoblox/konk-service:$(K8S_RELEASE) \
+		ghcr.io/infobloxopen/konk-app:$(K8S_RELEASE) ghcr.io/infobloxopen/konk-provision:$(K8S_RELEASE) \
+		ghcr.io/infobloxopen/konk-service:$(K8S_RELEASE) \
 		--name ${KIND_NAME}
 
 kind-load-apiserver: QUAY_IMG=$(shell $(HELM) template helm-charts/example-apiserver | awk '/image: quay/ {print $$2}')

--- a/helm-charts/example-apiserver/values.yaml
+++ b/helm-charts/example-apiserver/values.yaml
@@ -108,7 +108,7 @@ apiserver:
 
 kind:
   image:
-    repository: infoblox/konk-service
+    repository: ghcr.io/infobloxopen/konk-service
     pullPolicy: IfNotPresent
     tag: ""
 

--- a/helm-charts/konk-operator/values.yaml
+++ b/helm-charts/konk-operator/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: infoblox/konk
+  repository: ghcr.io/infobloxopen/konk
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -25,7 +25,7 @@ annotations: {}
 # No shell, no busybox — all kubectl/shell logic is implemented in Go.
 kind:
   image:
-    repository: infoblox/konk-service
+    repository: ghcr.io/infobloxopen/konk-service
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 apiserver:
   image:
-    repository: infoblox/konk-app
+    repository: ghcr.io/infobloxopen/konk-app
     pullPolicy: IfNotPresent
     # -- Overrides the image tag
     # @default -- default is the chart appVersion.
@@ -98,7 +98,7 @@ etcd:
 # -- provision is the init container that generates certs and kubeconfigs
 provision:
   image:
-    repository: infoblox/konk-provision
+    repository: ghcr.io/infobloxopen/konk-provision
     pullPolicy: IfNotPresent
     # -- Overrides the image tag
     # @default -- default is the chart appVersion.
@@ -118,7 +118,7 @@ provision:
 # No shell, no busybox — all kubectl/shell logic is implemented in Go.
 kind:
   image:
-    repository: infoblox/konk-service
+    repository: ghcr.io/infobloxopen/konk-service
     pullPolicy: IfNotPresent
     # -- Overrides the image tag
     # @default -- default is the chart appVersion.


### PR DESCRIPTION
Switch all 4 image targets (konk, konk-app, konk-provision, konk-service) from docker.io/infoblox/ to ghcr.io/infobloxopen/ to unblock CI push.

- **Makefile:** update IMG, PROVISION_IMG, KONK_SERVICE_IMG, KUBERNETES_IMG
- **helm-charts/konk/values.yaml:** update repository fields to ghcr.io/infobloxopen/
- .**github/workflows/push-images.yml:** add GitHub Actions workflow to build and push all images to GHCR using IBOPEN_GHCR_GITHUB_TOKEN
