### PR TITLE
fix: decouple image tags from chart version to match GHCR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
       -v ${env.WORKSPACE}:/pkg \
       -w /pkg \
       ${env.HELM_IMAGE}"""
-    GIT_DESCRIBE = sh(script: "git describe --always --long --tags", returnStdout: true).trim()
-    GIT_VERSION = "${env.GIT_DESCRIBE}-j${env.BUILD_NUMBER}"
+    GIT_VERSION = sh(script: "git describe --dirty=-unsupported --always --long --tags", returnStdout: true).trim()
+    CHART_VERSION = "${env.GIT_VERSION}-j${env.BUILD_NUMBER}"
   }
   stages {
     stage("Prepare Build") {
@@ -41,7 +41,7 @@ pipeline {
     stage("Package Charts") {
       steps {
         withAWS(credentials: "CICD_HELM", region: "us-east-1") {
-          sh 'make package'
+          sh 'make CHART_PKG_VERSION=$CHART_VERSION package'
         }
       }
     }
@@ -60,7 +60,7 @@ pipeline {
               for chart in konk*
               do
 
-              chart_file=$chart-$GIT_VERSION.tgz
+              chart_file=$chart-$CHART_VERSION.tgz
 
               $HELM s3 push /pkg/$chart_file infobloxcto
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CHART_DIR	:= helm-charts
 GIT_VERSION	?= $(shell git describe --dirty=-unsupported --always --long --tags)
+CHART_PKG_VERSION ?= $(GIT_VERSION)
 HELM_IMAGE	?= infoblox/helm:3
 DOCKER_RUNNER	?= docker run --rm -i \
 			--entrypoint="" \
@@ -53,7 +54,7 @@ deploy-cert-manager:
 		--set installCRDs=true \
 		--set extraArgs[0]="--enable-certificate-owner-ref=true""
 
-deploy-crds: konk-operator-${GIT_VERSION}.tgz
+deploy-crds: konk-operator-${CHART_PKG_VERSION}.tgz
 	# https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 	# > There is no support at this time for upgrading or deleting CRDs using Helm.
 	kubectl apply -f helm-charts/konk-operator/crds
@@ -208,16 +209,16 @@ else
 KUSTOMIZE=$(shell which kustomize)
 endif
 
-konk-operator-${GIT_VERSION}.tgz:
+konk-operator-${CHART_PKG_VERSION}.tgz:
 	mkdir -p helm-charts/konk-operator/crds
 	cp -vR config/crd/bases/* helm-charts/konk-operator/crds/
 	cp -vR config/rbac helm-charts/konk-operator/
-	${HELM} package helm-charts/konk-operator --version ${GIT_VERSION} --app-version ${GIT_VERSION}
+	${HELM} package helm-charts/konk-operator --version ${CHART_PKG_VERSION} --app-version ${GIT_VERSION}
 
-%-${GIT_VERSION}.tgz:
-	${HELM} package helm-charts/$* --version ${GIT_VERSION}
+%-${CHART_PKG_VERSION}.tgz:
+	${HELM} package helm-charts/$* --version ${CHART_PKG_VERSION}
 
-package: konk-operator-${GIT_VERSION}.tgz konk-${GIT_VERSION}.tgz konk-service-${GIT_VERSION}.tgz example-apiserver-${GIT_VERSION}.tgz
+package: konk-operator-${CHART_PKG_VERSION}.tgz konk-${CHART_PKG_VERSION}.tgz konk-service-${CHART_PKG_VERSION}.tgz example-apiserver-${CHART_PKG_VERSION}.tgz
 
 OPERATOR_VERSION:=v1.42.0
 ./bin/%: ./bin/%-$(OPERATOR_VERSION)


### PR DESCRIPTION
- Jenkins GIT_VERSION now uses plain git describe (matching Makefile/GH Actions). 
- Chart .tgz files use separate CHART_PKG_VERSION with -j$BUILD_NUMBER suffix. 
- The --app-version (operator image tag) stays as GIT_VERSION so pods pull the correct image from GHCR.