### PR TITLE
fix: use := for GIT_VERSION to prevent -unsupported tag in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
       -v ${env.WORKSPACE}:/pkg \
       -w /pkg \
       ${env.HELM_IMAGE}"""
-    GIT_VERSION = sh(script: "git describe --dirty=-unsupported --always --long --tags", returnStdout: true).trim()
+    GIT_VERSION = sh(script: "git describe --always --long --tags", returnStdout: true).trim()
     CHART_VERSION = "${env.GIT_VERSION}-j${env.BUILD_NUMBER}"
   }
   stages {

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CHART_DIR	:= helm-charts
-GIT_VERSION	?= $(shell git describe --dirty=-unsupported --always --long --tags)
+GIT_VERSION	:= $(shell git describe --always --long --tags)
 CHART_PKG_VERSION ?= $(GIT_VERSION)
 HELM_IMAGE	?= infoblox/helm:3
 DOCKER_RUNNER	?= docker run --rm -i \


### PR DESCRIPTION
- With ?= (recursive), GIT_VERSION is re-evaluated on every use.
- The .PHONY image-tag-values.yaml target regenerates and dirties the tree mid-build, causing subsequent expansions of GIT_VERSION to include -unsupported. 
- Using := evaluates once at parse time, before the tree is modified.