### PR TITLE
fix: use provision healthz for init readiness probe

### DIFF
--- a/helm-charts/konk/templates/init.yaml
+++ b/helm-charts/konk/templates/init.yaml
@@ -44,7 +44,8 @@ spec:
         readinessProbe:
           exec:
             command:
-              - cat
+              - /usr/local/bin/provision
+              - healthz
               - /tmp/ready
           periodSeconds: 10
           failureThreshold: 3


### PR DESCRIPTION
The distroless provision image has no 'cat' binary, so the readiness probe 'cat /tmp/ready' always fails. Use the healthz subcommand added in #609: '/usr/local/bin/provision healthz /tmp/ready'.