### PR TITLE
add image repository overrides to support Harbor registry

### DIFF
--- a/helm-charts/konk-operator/templates/deployment.yaml
+++ b/helm-charts/konk-operator/templates/deployment.yaml
@@ -47,6 +47,12 @@ spec:
               value: {{ .Values.relatedImages.provision | default "" | quote }}
             - name: RELATED_IMAGE_KIND
               value: {{ .Values.relatedImages.kind | default "" | quote }}
+            - name: RELATED_IMAGE_APISERVER_REPO
+              value: {{ .Values.relatedImages.apiserverRepository | default "" | quote }}
+            - name: RELATED_IMAGE_PROVISION_REPO
+              value: {{ .Values.relatedImages.provisionRepository | default "" | quote }}
+            - name: RELATED_IMAGE_KIND_REPO
+              value: {{ .Values.relatedImages.kindRepository | default "" | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm-charts/konk-operator/values.yaml
+++ b/helm-charts/konk-operator/values.yaml
@@ -74,10 +74,14 @@ vaultCommon:
     keys: []
     type: kubernetes.io/dockerconfigjson
 
-# Image tags for konk sub-charts, passed as env vars to the operator.
+# Image tags and repositories for konk sub-charts, passed as env vars to the operator.
 # When set, these override the chart's default appVersion fallback.
 # In CI/kind, these are set to K8S_RELEASE-GIT_SHORT (e.g. v1.25.8-gabcdef).
+# Repository fields default to GHCR; override per-cluster to use Harbor or another registry.
 relatedImages:
   apiserver: ""
   provision: ""
   kind: ""
+  apiserverRepository: "ghcr.io/infobloxopen/konk-app"
+  provisionRepository: "ghcr.io/infobloxopen/konk-provision"
+  kindRepository: "ghcr.io/infobloxopen/konk-service"

--- a/watches.yaml
+++ b/watches.yaml
@@ -10,8 +10,11 @@
     certManager.namespace: $CERT_MANAGER_NAMESPACE
     space.enabled: $SPACE
     vaultCommon.imagepullsecret.path: $VAULT_PATH
+    apiserver.image.repository: $RELATED_IMAGE_APISERVER_REPO
     apiserver.image.tag: $RELATED_IMAGE_APISERVER
+    provision.image.repository: $RELATED_IMAGE_PROVISION_REPO
     provision.image.tag: $RELATED_IMAGE_PROVISION
+    kind.image.repository: $RELATED_IMAGE_KIND_REPO
     kind.image.tag: $RELATED_IMAGE_KIND
 - group: konk.infoblox.com
   version: v1alpha1
@@ -21,6 +24,7 @@
     authURL: $AUTH_URL
     space.enabled: $SPACE
     vaultCommon.imagepullsecret.path: $VAULT_PATH
+    kind.image.repository: $RELATED_IMAGE_KIND_REPO
     kind.image.tag: $RELATED_IMAGE_KIND
 - group: konk.infoblox.com
   version: v1alpha1


### PR DESCRIPTION
Add relatedImages.*Repository fields and RELATED_IMAGE_*_REPO env vars so that per-cluster deployment configs can override the image registry (e.g. Harbor) without changing the chart defaults (GHCR).

Changes:
- konk-operator values.yaml: add apiserverRepository, provisionRepository, kindRepository with GHCR defaults
- konk-operator deployment.yaml: pass *_REPO env vars to operator pod
- watches.yaml: wire *.image.repository overrides for Konk and KonkService CRs