### PR TITLE
fix(konk-service): truncate deployment names to prevent linkerd label…

### DIFF
--- a/helm-charts/konk-service/templates/apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "konk-service.fullname" . }}-kubectl-apiservice
+  name: {{ include "konk-service.fullname" . | trunc 43 | trimSuffix "-" }}-kubectl-apiservice
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "konk-service.fullname" . }}-kubectl-apiservice-test
+  name: {{ include "konk-service.fullname" . | trunc 40 | trimSuffix "-" }}-kubectl-apiservice-test
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "konk-service.fullname" . }}-kubeconfig
+  name: {{ include "konk-service.fullname" . | trunc 52 | trimSuffix "-" }}-kubeconfig
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}


### PR DESCRIPTION
… length error

Truncate fullname in deployment names to ensure the final name stays
within Kubernetes' 63-character label value limit. This prevents
FailedCreate errors when linkerd injects the proxy-deployment label.

- apiservice-deployment: trunc 43
- apiservice-test-deployment: trunc 40
- kubeconfig-deployment: trunc 52