### PR TITLE
Fix: Feature/cert expiry crash restart

### DIFF
--- a/cmd/konk-service/cert_check.go
+++ b/cmd/konk-service/cert_check.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"time"
+)
+
+// parseCertExpiry parses PEM-encoded certificate data and returns the NotAfter time.
+// If multiple certs are present (chain), it returns the earliest expiry.
+func parseCertExpiry(certPEM []byte) (time.Time, error) {
+	var earliest time.Time
+	rest := certPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parsing certificate: %w", err)
+		}
+		if earliest.IsZero() || cert.NotAfter.Before(earliest) {
+			earliest = cert.NotAfter
+		}
+	}
+	if earliest.IsZero() {
+		return time.Time{}, fmt.Errorf("no certificates found in PEM data")
+	}
+	return earliest, nil
+}
+
+// checkCertExpiry logs the certificate expiry status and returns an error if expired.
+func checkCertExpiry(label string, certPEM []byte) error {
+	expiry, err := parseCertExpiry(certPEM)
+	if err != nil {
+		log.Printf("WARNING: could not parse %s certificate: %v", label, err)
+		return nil // don't block on parse errors
+	}
+
+	remaining := time.Until(expiry)
+	switch {
+	case remaining <= 0:
+		log.Printf("ERROR: %s certificate EXPIRED at %s (%s ago)",
+			label, expiry.UTC().Format(time.RFC3339), -remaining)
+		return fmt.Errorf("%s certificate expired at %s", label, expiry.UTC().Format(time.RFC3339))
+	case remaining < 1*time.Hour:
+		log.Printf("WARNING: %s certificate expires in %s (at %s)",
+			label, remaining.Round(time.Second), expiry.UTC().Format(time.RFC3339))
+	case remaining < 4*time.Hour:
+		log.Printf("INFO: %s certificate expires in %s (at %s)",
+			label, remaining.Round(time.Minute), expiry.UTC().Format(time.RFC3339))
+	default:
+		log.Printf("%s certificate valid, expires in %s", label, remaining.Round(time.Minute))
+	}
+	return nil
+}

--- a/cmd/konk-service/reconcile_apiservice.go
+++ b/cmd/konk-service/reconcile_apiservice.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // runReconcileAPIService replaces apiservice-deployment.yaml + deploy-api-service.sh.
@@ -34,11 +36,26 @@ func runReconcileAPIService() error {
 
 	ctx := context.Background()
 
+	const maxConsecutiveErrors = 10
+	consecutiveErrors := 0
+
 	for {
 		err := reconcileAPIServiceOnce(ctx, kubeconfigPath, certDir, serviceName, namespace, manifests, crds, crdManifests)
 		if err != nil {
-			log.Printf("Error reconciling APIService: %v", err)
+			consecutiveErrors++
+			log.Printf("Error reconciling APIService (%d/%d consecutive): %v",
+				consecutiveErrors, maxConsecutiveErrors, err)
+			if consecutiveErrors >= maxConsecutiveErrors {
+				// Remove health file so readiness probe fails immediately
+				os.Remove("/tmp/healthy")
+				log.Fatalf("FATAL: %d consecutive reconciliation failures — exiting so pod restarts with fresh certs. Last error: %v",
+					maxConsecutiveErrors, err)
+			}
 		} else {
+			if consecutiveErrors > 0 {
+				log.Printf("Reconciliation recovered after %d consecutive errors", consecutiveErrors)
+			}
+			consecutiveErrors = 0
 			if err := writeHealthFile("/tmp/healthy", 0); err != nil {
 				log.Printf("Warning: failed to write health file: %v", err)
 			}
@@ -55,6 +72,25 @@ func reconcileAPIServiceOnce(ctx context.Context, kubeconfigPath, certDir, servi
 		return fmt.Errorf("reading ca.crt: %w", err)
 	}
 	certB64 := base64.StdEncoding.EncodeToString(caCertRaw)
+
+	// Read the kubeconfig to check client cert expiry
+	kubeconfigData, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("reading kubeconfig for cert check: %w", err)
+	}
+	kubeconfig, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		log.Printf("WARNING: could not parse kubeconfig for cert check: %v", err)
+	} else {
+		for _, authInfo := range kubeconfig.AuthInfos {
+			if len(authInfo.ClientCertificateData) > 0 {
+				if err := checkCertExpiry("apiservice client", authInfo.ClientCertificateData); err != nil {
+					log.Printf("CRITICAL: kubeconfig client cert is expired — requests to konk will fail with x509 errors")
+				}
+				break
+			}
+		}
+	}
 
 	// Template the manifests
 	// The Helm backtick-escaped placeholders (e.g. {{` {{ SERVICENAME }} `}})

--- a/cmd/konk-service/reconcile_kubeconfig.go
+++ b/cmd/konk-service/reconcile_kubeconfig.go
@@ -52,13 +52,31 @@ func runReconcileKubeconfig() error {
 	secretName := fullname + "-kubeconfig"
 	var lastCertSum string
 
+	const maxConsecutiveErrors = 10
+	consecutiveErrors := 0
+
 	for {
 		log.Println("Reconciling kubeconfig...")
-		reconcileOnce(ctx, infraClient, kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName, labels, &lastCertSum)
+		err = reconcileOnce(ctx, infraClient, kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName, labels, &lastCertSum)
+		if err != nil {
+			consecutiveErrors++
+			log.Printf("Error reconciling kubeconfig (%d/%d consecutive): %v",
+				consecutiveErrors, maxConsecutiveErrors, err)
+			if consecutiveErrors >= maxConsecutiveErrors {
+				os.Remove("/tmp/status")
+				log.Fatalf("FATAL: %d consecutive kubeconfig reconciliation failures — exiting so pod restarts. Last error: %v",
+					maxConsecutiveErrors, err)
+			}
+		} else {
+			if consecutiveErrors > 0 {
+				log.Printf("Kubeconfig reconciliation recovered after %d consecutive errors", consecutiveErrors)
+			}
+			consecutiveErrors = 0
+		}
 
-		// 3 minute loop with 30s jitter (matching original shell)
-		jitter := time.Duration(rand.Intn(30)) * time.Second
-		time.Sleep(150*time.Second + jitter)
+		// 1 minute loop with 10s jitter for faster cert rotation pickup
+		jitter := time.Duration(rand.Intn(10)) * time.Second
+		time.Sleep(60*time.Second + jitter)
 	}
 }
 
@@ -68,23 +86,26 @@ func reconcileOnce(
 	kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName string,
 	labels map[string]string,
 	lastCertSum *string,
-) {
+) error {
 	// Read certs from the mounted cert-manager secret
 	caCert, err := os.ReadFile(certDir + "/ca.crt")
 	if err != nil {
-		log.Printf("Error reading ca.crt: %v", err)
-		return
+		return fmt.Errorf("reading ca.crt: %w", err)
 	}
 	tlsCert, err := os.ReadFile(certDir + "/tls.crt")
 	if err != nil {
-		log.Printf("Error reading tls.crt: %v", err)
-		return
+		return fmt.Errorf("reading tls.crt: %w", err)
 	}
 	tlsKey, err := os.ReadFile(certDir + "/tls.key")
 	if err != nil {
-		log.Printf("Error reading tls.key: %v", err)
-		return
+		return fmt.Errorf("reading tls.key: %w", err)
 	}
+
+	// Validate cert expiry — log warnings for expiring certs
+	if err := checkCertExpiry("kubeconfig client", tlsCert); err != nil {
+		log.Printf("CRITICAL: client cert is expired, kubeconfig will be rejected by konk: %v", err)
+	}
+	checkCertExpiry("kubeconfig CA", caCert)
 
 	// Build a kubeconfig programmatically
 	kubeconfig := clientcmdapi.NewConfig()
@@ -104,18 +125,15 @@ func reconcileOnce(
 
 	kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
 	if err != nil {
-		log.Printf("Error serializing kubeconfig: %v", err)
-		return
+		return fmt.Errorf("serializing kubeconfig: %w", err)
 	}
 
 	dir := kubeconfigPath[:strings.LastIndex(kubeconfigPath, "/")]
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Printf("Error creating kubeconfig dir: %v", err)
-		return
+		return fmt.Errorf("creating kubeconfig dir: %w", err)
 	}
 	if err := os.WriteFile(kubeconfigPath, kubeconfigBytes, 0600); err != nil {
-		log.Printf("Error writing kubeconfig: %v", err)
-		return
+		return fmt.Errorf("writing kubeconfig: %w", err)
 	}
 
 	// Compute cert checksum to detect rotation
@@ -130,8 +148,9 @@ func reconcileOnce(
 
 	err = reconcileKubeconfigSecret(ctx, infraClient, namespace, secretName, fullname, labels, secretData, certSum, lastCertSum)
 	if err != nil {
-		log.Printf("Error reconciling secret: %v", err)
+		return fmt.Errorf("reconciling secret: %w", err)
 	}
+	return nil
 }
 
 func parseLabels(labelsStr string) map[string]string {


### PR DESCRIPTION
**fix: crash pod on persistent cert failures to trigger restart

- Add cert_check.go: parse PEM certs and log expiry warnings at <4h, <1h, expired thresholds
- reconcile-apiservice: validate kubeconfig client cert expiry each loop, crash after 10 consecutive errors (~5min)
- reconcile-kubeconfig: validate cert expiry after reading from disk, return errors instead of silent log, crash after 10 consecutive errors (~10min), reduce polling from 150s to 60s

When certs expire and reconciliation fails repeatedly, pods now exit so Kubernetes restarts them with freshly projected Secret volumes instead of running indefinitely with stale certs.**