### PR TITLE
Add the smoke tests and fix the CI checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,7 +91,7 @@ jobs:
           make deploy-cert-manager deploy-ingress-nginx INGRESS_VERSION=${{ matrix.ingressVersion || env.ingress_version }}
       - name: Install konk-operator
         if: ${{ matrix.isUpgrade }}
-        timeout-minutes: 6
+        timeout-minutes: 15
         run: |
           make kind-load-konk KIND_NAME="chart-testing"
           make deploy-konk-operator
@@ -158,6 +158,9 @@ jobs:
           do
             sleep 1
           done
+          echo "::group::Debug - helm releases (all namespaces)"
+          helm list -A || true
+          echo "::endgroup::"
           make test-konk KONK_NAMESPACE=$KONK_NAMESPACE
           make test-konk-local
       - name: Setup Go

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,8 +93,16 @@ jobs:
         if: ${{ matrix.isUpgrade }}
         timeout-minutes: 15
         run: |
-          make kind-load-konk KIND_NAME="chart-testing"
-          make deploy-konk-operator
+          # Pin GIT_VERSION for the whole upgrade leg so both `make` invocations
+          # (this step and the subsequent "Install/Upgrade konk-operator" step,
+          # run from a different checkout) build & reference the same image
+          # tags and produce identical helm overrideValues. Without this, the
+          # operator-led `runner-konk` release rewrites on the second pass and
+          # `helm test runner-konk` cannot find it.
+          GIT_VERSION="$(git describe --always --long --tags)"
+          echo "GIT_VERSION=${GIT_VERSION}" >> "$GITHUB_ENV"
+          make kind-load-konk KIND_NAME="chart-testing" GIT_VERSION="${GIT_VERSION}"
+          make deploy-konk-operator GIT_VERSION="${GIT_VERSION}"
           kubectl create ns $KONK_NAMESPACE || true
           kubectl create -n $KONK_NAMESPACE -f examples/konk.yaml
           until kubectl wait -n $KONK_NAMESPACE --timeout=3m --for=condition=ready pod -l app.kubernetes.io/component=apiserver,app.kubernetes.io/name=konk
@@ -113,8 +121,16 @@ jobs:
       - name: Install/Upgrade konk-operator
         timeout-minutes: 10
         run: |
-          make kind-load-konk KIND_NAME="chart-testing"
-          make deploy-crds deploy-konk-operator
+          # Reuse the pinned GIT_VERSION from the upgrade leg's first install
+          # (set above via $GITHUB_ENV). For the non-upgrade legs GIT_VERSION
+          # is empty and the Makefile falls back to `git describe`.
+          if [ -n "${GIT_VERSION:-}" ]; then
+            make kind-load-konk KIND_NAME="chart-testing" GIT_VERSION="${GIT_VERSION}"
+            make deploy-crds deploy-konk-operator GIT_VERSION="${GIT_VERSION}"
+          else
+            make kind-load-konk KIND_NAME="chart-testing"
+            make deploy-crds deploy-konk-operator
+          fi
       - name: Test Konk
         timeout-minutes: 6
         run: |
@@ -159,7 +175,10 @@ jobs:
             sleep 1
           done
           echo "::group::Debug - helm releases (all namespaces)"
-          helm list -A || true
+          docker run --rm --network host \
+            -v ${HOME}/.kube:/root/.kube \
+            -e KUBECONFIG=/root/.kube/config \
+            infoblox/helm:3 helm list -A || true
           echo "::endgroup::"
           make test-konk KONK_NAMESPACE=$KONK_NAMESPACE
           make test-konk-local

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ helm-charts/konk-operator/rbac
 helm-charts/konk/image-tag-values.yaml
 cmd/provision/provision
 cmd/konk-service/konk-service
+
+# Smoke test artifact (regenerated locally per run)
+/reports/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CHART_DIR	:= helm-charts
-GIT_VERSION	:= $(shell git describe --always --long --tags)
+GIT_VERSION	?= $(shell git describe --always --long --tags)
 CHART_PKG_VERSION ?= $(GIT_VERSION)
 HELM_IMAGE	?= infoblox/helm:3
 DOCKER_RUNNER	?= docker run --rm -i \

--- a/smoke-test-plan.json
+++ b/smoke-test-plan.json
@@ -1,0 +1,486 @@
+{
+  "service_summary": {
+    "service_name": "konk",
+    "description": "konk (Kubernetes On Kubernetes) deploys an independent Kubernetes API server within Kubernetes. The repository ships an operator-sdk Helm-based operator that watches three Custom Resources and reconciles them by installing the corresponding Helm charts.",
+    "components": [
+      {
+        "name": "konk-operator",
+        "type": "operator-sdk Helm operator",
+        "watches_file": "konk/watches.yaml",
+        "watches": [
+          "konk.infoblox.com/v1alpha1/Konk -> helm-charts/konk",
+          "konk.infoblox.com/v1alpha1/KonkService -> helm-charts/konk-service",
+          "konk.infoblox.com/v1alpha1/Etcd -> helm-charts/etcd"
+        ],
+        "deployed_in_us_dev_5": {
+          "namespace": "konk",
+          "deployment": "konk-operator",
+          "image": "harbor.services.sdp.infoblox.com/infobloxcto/konk:v0.2.1-175-g1d5d187",
+          "metrics_service_present": false
+        }
+      },
+      {
+        "name": "konk (deployed instance)",
+        "type": "kube-apiserver + etcd",
+        "purpose": "Independent Kubernetes API server stood up by the Konk CR",
+        "existing_in_us_dev_5": {
+          "namespace": "aggregate",
+          "name": "bulk-konk",
+          "scope": "cluster",
+          "status": "Deployed=True reason=UpgradeSuccessful",
+          "warning": "Production: hosts 16 live KonkServices. Smoke tests must NOT touch it."
+        }
+      },
+      {
+        "name": "konk-service",
+        "type": "Helm chart",
+        "purpose": "Registers an APIService inside the konk-deployed apiserver to enable extension API servers"
+      }
+    ],
+    "core_resource_lifecycle": "User creates a Konk/KonkService/Etcd CR in the parent cluster. The konk-operator (Helm operator) reconciles by installing/upgrading the matching Helm release. Status conditions Initialized/Deployed with reason ending in 'Successful' indicate health. Deleting the CR triggers Helm uninstall.",
+    "authentication_flow": "All exposed surfaces are Kubernetes API endpoints. Authentication is performed by the parent kube-apiserver using the caller's kubeconfig (X.509 client certs or bearer tokens). Authorization is enforced via RBAC. The operator implements no custom HTTP authentication; the kube-rbac-proxy sidecar performs SubjectAccessReview-based RBAC for the /metrics endpoint.",
+    "external_dependencies": [
+      "Parent Kubernetes cluster (kube-apiserver, RBAC)",
+      "cert-manager (certificate issuance for konk and konk-service)",
+      "Helm (release management performed by the operator)",
+      "etcd (deployed via the etcd Helm chart for konk persistence)"
+    ],
+    "endpoint_grouping_by_domain": [
+      "Konk CR lifecycle (CRUD on konks.konk.infoblox.com)",
+      "KonkService CR lifecycle (CRUD on konkservices.konk.infoblox.com)",
+      "Etcd CR lifecycle (CRUD on etcds.konk.infoblox.com)",
+      "Operator observability (/metrics via kube-rbac-proxy) — conditional, may be absent in lower environments"
+    ]
+  },
+  "endpoint_catalog": {
+    "source": "repository_scan",
+    "discovery_notes": [
+      "No Swagger/OpenAPI specification was provided.",
+      "konk-operator is an operator-sdk Helm operator (konk/watches.yaml). Repository scan for router.Handle / HandleFunc / mux / gin / echo / http.NewServeMux / grpc-gateway annotations returned no custom Go HTTP route registrations in the konk source tree.",
+      "All externally observable REST endpoints are therefore the Kubernetes API endpoints that the parent kube-apiserver dynamically serves for the CRDs registered by this project, plus the controller-manager /metrics endpoint exposed via kube-rbac-proxy.",
+      "CRDs scanned: konk/config/crd/bases/konk.infoblox.com_konks.yaml, konk/config/crd/bases/konk.infoblox.com_konkservices.yaml, konk/config/crd/bases/konk.infoblox.com_etcds.yaml.",
+      "Metrics endpoint defined in konk/config/default/manager_auth_proxy_patch.yaml (kube-rbac-proxy --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:8080/). Verified ABSENT in us-dev-5 deployment but expected in higher environments; the corresponding scenarios are conditional."
+    ],
+    "endpoints": [
+      { "id": "konk_list",            "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks",                  "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "konk_create",          "method": "POST",   "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks",                  "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "konk_get",             "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "konk_update",          "method": "PUT",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "konk_patch",           "method": "PATCH",  "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "konk_delete",          "method": "DELETE", "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml",         "resource": "konks.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "konk_status_get",      "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}/status",    "handler": "kube-apiserver (CRD status subresource)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml", "resource": "konks.konk.infoblox.com/status", "category": "retrieval", "scope": "Namespaced" },
+      { "id": "konk_status_patch",    "method": "PATCH",  "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konks/{name}/status",    "handler": "kube-apiserver (CRD status subresource)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konks.yaml", "resource": "konks.konk.infoblox.com/status", "category": "administration", "scope": "Namespaced" },
+
+      { "id": "konkservice_list",     "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "konkservice_create",   "method": "POST",   "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "crud",           "scope": "Namespaced" },
+      { "id": "konkservice_get",      "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices/{name}",    "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "konkservice_update",   "method": "PUT",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices/{name}",    "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "crud",           "scope": "Namespaced" },
+      { "id": "konkservice_patch",    "method": "PATCH",  "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices/{name}",    "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "crud",           "scope": "Namespaced" },
+      { "id": "konkservice_delete",   "method": "DELETE", "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices/{name}",    "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml",  "resource": "konkservices.konk.infoblox.com",  "category": "crud",           "scope": "Namespaced" },
+      { "id": "konkservice_status_get","method": "GET",   "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/konkservices/{name}/status","handler": "kube-apiserver (CRD status subresource)", "source_file": "konk/config/crd/bases/konk.infoblox.com_konkservices.yaml", "resource": "konkservices.konk.infoblox.com/status", "category": "retrieval", "scope": "Namespaced" },
+
+      { "id": "etcd_list",            "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds",                  "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "etcd_create",          "method": "POST",   "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds",                  "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "etcd_get",             "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "retrieval",      "scope": "Namespaced" },
+      { "id": "etcd_update",          "method": "PUT",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "etcd_patch",           "method": "PATCH",  "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "etcd_delete",          "method": "DELETE", "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds/{name}",           "handler": "kube-apiserver (CRD-backed)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml",         "resource": "etcds.konk.infoblox.com",         "category": "crud",           "scope": "Namespaced" },
+      { "id": "etcd_status_get",      "method": "GET",    "path": "/apis/konk.infoblox.com/v1alpha1/namespaces/{namespace}/etcds/{name}/status",    "handler": "kube-apiserver (CRD status subresource)", "source_file": "konk/config/crd/bases/konk.infoblox.com_etcds.yaml", "resource": "etcds.konk.infoblox.com/status", "category": "retrieval", "scope": "Namespaced" },
+
+      { "id": "operator_metrics",     "method": "GET",    "path": "/metrics",                                                                       "handler": "controller-runtime metrics server fronted by kube-rbac-proxy", "source_file": "konk/config/default/manager_auth_proxy_patch.yaml", "resource": "operator observability", "category": "observability", "scope": "Cluster (Service: <operator-metrics-service>:8443)", "availability": "conditional", "warning": "NOT present in us-dev-5 (deployed konk-operator has no kube-rbac-proxy sidecar and no metrics Service in the konk namespace). Expected to be enabled in higher environments. Tests must skip with a warning if METRICS_URL is unset." }
+    ]
+  },
+  "smoke_scenarios": [
+    {
+      "scenario_id": "SC-01",
+      "scenario_name": "Konk CR full lifecycle (create -> get -> list -> patch -> status -> delete)",
+      "type": "positive",
+      "category": "crud",
+      "objective": "Validate that the konk-operator accepts a valid Konk CR, the kube-apiserver persists it, the operator reconciles to a healthy state (Deployed=True, reason ending in 'Successful'), and the resource can be cleanly removed.",
+      "involved_endpoints": ["konk_create", "konk_get", "konk_list", "konk_patch", "konk_status_get", "konk_delete"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_success_conditions": [
+        "POST returns 201 with the created Konk object",
+        "GET returns 200 and metadata.name matches",
+        "LIST returns 200 with items[]",
+        "PATCH (label change) returns 200 and persists",
+        "Status polling observes conditions[type=Deployed,status=True,reason ~ /Successful$/] within timeout",
+        "DELETE returns 200/202; subsequent GET returns 404 within timeout"
+      ],
+      "cleanup_requirements": [
+        "DELETE the Konk by name",
+        "Confirm 404 on follow-up GET",
+        "DELETE the dynamically created namespace used for isolation"
+      ],
+      "dependency_assumptions": [
+        "konk-operator is running in the cluster",
+        "cert-manager is installed",
+        "Caller identity has RBAC for konks.konk.infoblox.com in the test namespace",
+        "Cluster matches allowlist (default: us-dev-5)"
+      ]
+    },
+    {
+      "scenario_id": "SC-02",
+      "scenario_name": "KonkService CR full lifecycle",
+      "type": "positive",
+      "category": "crud",
+      "objective": "Validate that a KonkService CR is accepted, persisted, reconciled by the operator, and cleanly deleted.",
+      "involved_endpoints": ["konkservice_create", "konkservice_get", "konkservice_list", "konkservice_patch", "konkservice_status_get", "konkservice_delete"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_success_conditions": [
+        "POST returns 201 for a valid KonkService spec referencing an existing Konk (spec.konk.name matches '^.+-konk$')",
+        "GET returns 200 with matching spec",
+        "LIST returns 200 with items[]",
+        "PATCH on metadata.labels succeeds",
+        "Status eventually contains Deployed=True with reason ending in 'Successful'",
+        "DELETE returns 200/202; follow-up GET returns 404"
+      ],
+      "cleanup_requirements": [
+        "DELETE the KonkService",
+        "DELETE the parent Konk created for this scenario",
+        "DELETE the test namespace"
+      ],
+      "dependency_assumptions": [
+        "A Konk created within the scenario is healthy",
+        "cert-manager is available for certificate issuance"
+      ]
+    },
+    {
+      "scenario_id": "SC-03",
+      "scenario_name": "Etcd CR create and delete",
+      "type": "positive",
+      "category": "crud",
+      "objective": "Validate that the Etcd CR can be created, retrieved, listed, and deleted via the operator-managed Helm chart.",
+      "involved_endpoints": ["etcd_create", "etcd_get", "etcd_list", "etcd_delete"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_success_conditions": [
+        "POST returns 201 for a minimal Etcd spec",
+        "GET returns 200",
+        "LIST returns 200 with items[]",
+        "DELETE returns 200/202; follow-up GET returns 404"
+      ],
+      "cleanup_requirements": [
+        "DELETE the Etcd CR",
+        "DELETE the test namespace"
+      ],
+      "dependency_assumptions": ["konk-operator running and watching Etcd CRs"]
+    },
+    {
+      "scenario_id": "SC-04",
+      "scenario_name": "Operator metrics endpoint reachable with valid token (conditional)",
+      "type": "positive",
+      "category": "observability",
+      "conditional": true,
+      "skip_when": "METRICS_URL or METRICS_TOKEN env var is unset",
+      "warning": "NOT validated in us-dev-5 (metrics surface absent there). Expected to pass in higher environments where the operator is deployed with the kube-rbac-proxy sidecar enabled.",
+      "objective": "Validate that the controller-manager metrics endpoint is reachable through kube-rbac-proxy when called with a ServiceAccount token holding the appropriate ClusterRole binding.",
+      "involved_endpoints": ["operator_metrics"],
+      "auth_type": "service_account_token (s2s)",
+      "expected_success_conditions": [
+        "GET https://<operator-metrics-service>.<ns>.svc:8443/metrics returns 200",
+        "Response body is Prometheus exposition format (contains '# HELP' or '# TYPE' lines)"
+      ],
+      "cleanup_requirements": ["Delete any temporary ClusterRoleBinding/ServiceAccount provisioned by the test"],
+      "dependency_assumptions": [
+        "kube-rbac-proxy sidecar is running in the target environment",
+        "Test caller can mint a ServiceAccount token bound to the metrics ClusterRole"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-01",
+      "scenario_name": "Reject Konk create with invalid spec.scope",
+      "type": "negative",
+      "category": "crud",
+      "objective": "Verify the CRD schema rejects Konk objects whose spec.scope does not match the pattern '^cluster|namespace$'.",
+      "involved_endpoints": ["konk_create"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_failure_conditions": [
+        "POST returns 422 Invalid (or 400) referencing spec.scope and the regex constraint",
+        "Follow-up GET by name returns 404 (not persisted)"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-02",
+      "scenario_name": "Reject KonkService create missing required fields or violating konk.name regex",
+      "type": "negative",
+      "category": "crud",
+      "objective": "Verify the CRD schema rejects KonkService objects missing required fields (group, konk, service, version) or whose spec.konk.name does not match '^.+-konk$'.",
+      "involved_endpoints": ["konkservice_create"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_failure_conditions": [
+        "POST without one of the required fields returns 422 Invalid",
+        "POST with spec.konk.name='not-matching-pattern' returns 422 Invalid",
+        "No object is persisted"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-03",
+      "scenario_name": "Reject create without authentication (conditional)",
+      "type": "negative",
+      "category": "configuration",
+      "conditional": true,
+      "skip_when": "KUBE_USE_PROXY=true (kubectl proxy injects kubeconfig identity, so unauthenticated requests cannot be exercised through it)",
+      "objective": "Verify unauthenticated callers cannot create Konk/KonkService/Etcd resources.",
+      "involved_endpoints": ["konk_create", "konkservice_create", "etcd_create"],
+      "auth_type": "none",
+      "expected_failure_conditions": [
+        "POST without Authorization header returns 401 Unauthorized (or 403 if anonymous is bound to a role without create)"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-04",
+      "scenario_name": "Reject get on non-existent resource id",
+      "type": "negative",
+      "category": "retrieval",
+      "objective": "Verify that fetching a non-existent CR returns 404.",
+      "involved_endpoints": ["konk_get", "konkservice_get", "etcd_get"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_failure_conditions": [
+        "GET .../konks/auto-test-does-not-exist-<rand>-konk returns 404 NotFound"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-05",
+      "scenario_name": "DELETE on non-existent resource returns 404",
+      "type": "negative",
+      "category": "crud",
+      "objective": "Verify that DELETE against a fabricated non-existent (AUTO_TEST_-prefixed) name returns 404 and performs no mutation. The 'no mutation against pre-existing resources' invariant is enforced as a code-level guardrail (ensureAutoTest / safeDelete in helpers/resourceHelpers.js) applied across all scenarios, not as a standalone scenario.",
+      "involved_endpoints": ["konk_delete"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_failure_conditions": [
+        "DELETE .../konks/auto-test-del-missing-<rand>-konk returns 404 NotFound"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-06",
+      "scenario_name": "Reject create in non-existent namespace",
+      "type": "negative",
+      "category": "crud",
+      "objective": "Verify the kube-apiserver rejects Konk creation when the target namespace does not exist.",
+      "involved_endpoints": ["konk_create"],
+      "auth_type": "user_jwt_or_kubeconfig",
+      "expected_failure_conditions": [
+        "POST to /apis/konk.infoblox.com/v1alpha1/namespaces/<non-existent>/konks returns 4xx (typically 404)",
+        "No object is persisted"
+      ]
+    },
+    {
+      "scenario_id": "SC-N-07",
+      "scenario_name": "Metrics endpoint requires authentication (conditional)",
+      "type": "negative",
+      "category": "observability",
+      "conditional": true,
+      "skip_when": "METRICS_URL env var is unset",
+      "warning": "NOT validated in us-dev-5. Expected to pass in higher environments with kube-rbac-proxy enabled.",
+      "objective": "Verify the kube-rbac-proxy denies unauthenticated and unauthorized requests to /metrics.",
+      "involved_endpoints": ["operator_metrics"],
+      "auth_type": "none",
+      "expected_failure_conditions": [
+        "GET /metrics with no token returns 401 Unauthorized",
+        "GET /metrics with an invalid token returns 401 Unauthorized",
+        "GET /metrics with a valid but unauthorized token returns 403 Forbidden"
+      ]
+    }
+  ],
+  "coverage_design": {
+    "endpoint_coverage_map": {
+      "konk_create":            ["SC-01", "SC-02", "SC-N-01", "SC-N-03", "SC-N-06"],
+      "konk_get":               ["SC-01", "SC-N-01", "SC-N-04"],
+      "konk_list":              ["SC-01"],
+      "konk_update":            [],
+      "konk_patch":             ["SC-01"],
+      "konk_delete":            ["SC-01 (cleanup)", "SC-02 (cleanup)", "SC-N-05"],
+      "konk_status_get":        ["SC-01"],
+      "konk_status_patch":      [],
+      "konkservice_create":     ["SC-02", "SC-N-02", "SC-N-03"],
+      "konkservice_get":        ["SC-02", "SC-N-04"],
+      "konkservice_list":       ["SC-02"],
+      "konkservice_update":     [],
+      "konkservice_patch":      ["SC-02"],
+      "konkservice_delete":     ["SC-02 (cleanup)"],
+      "konkservice_status_get": ["SC-02"],
+      "etcd_create":            ["SC-03", "SC-N-03"],
+      "etcd_get":               ["SC-03", "SC-N-04"],
+      "etcd_list":              ["SC-03"],
+      "etcd_update":            [],
+      "etcd_patch":             [],
+      "etcd_delete":            ["SC-03 (cleanup)"],
+      "etcd_status_get":        [],
+      "operator_metrics":       ["SC-04", "SC-N-07"]
+    },
+    "verification_strategy": {
+      "approach": "Per request: assert HTTP status code; for create/get/list assert response body matches a minimal JSON schema (apiVersion, kind, metadata.name, metadata.uid present). For lifecycle scenarios, additionally poll the status subresource and assert presence of conditions[type=Deployed,status=True,reason matches /Successful$/].",
+      "polling": {
+        "max_wait_seconds": 300,
+        "interval_seconds": 5,
+        "applies_to": ["SC-01", "SC-02", "SC-03"],
+        "deployed_reason_regex": "^(Install|Upgrade)?Successful$"
+      },
+      "logging": "Every request must log method, full URL, status code, and response body (truncated). Failed assertions must fail fast with a clear message identifying scenario_id and endpoint id."
+    },
+    "cleanup_strategy": {
+      "ordering": [
+        "Delete KonkService CRs first",
+        "Delete Etcd CRs",
+        "Delete Konk CRs",
+        "Delete the test namespace last"
+      ],
+      "guards": [
+        "Cleanup only operates on objects whose metadata.name begins with the run-scoped prefix 'AUTO_TEST_' (RFC1123-safe form 'auto-test-' for Kubernetes)",
+        "Cleanup runs in K6 teardown() and must execute even if checks failed",
+        "Each delete is followed by a bounded poll for 404 to confirm removal",
+        "Namespace deletion is best-effort and bounded by a timeout"
+      ]
+    },
+    "authentication_strategy": {
+      "primary_auth": "Two supported modes: (1) BEARER TOKEN — Kubernetes ServiceAccount token or user kubeconfig token, supplied via env var KUBE_BEARER_TOKEN; API URL via KUBE_API_URL; insecure flag KUBE_INSECURE_SKIP_TLS_VERIFY=true (off by default). (2) KUBECTL PROXY — set KUBE_USE_PROXY=true and KUBE_API_URL=http://127.0.0.1:8001 (after running 'kubectl proxy --port=8001'); the proxy uses the caller's kubeconfig identity, and the test suite suppresses any Authorization header. SC-N-03 is auto-skipped in proxy mode because unauthenticated calls cannot be exercised through the proxy. Optional generic JWT mode (AUTH_MODE=jwt) using BASE_URL/USER_EMAIL/USER_PASSWORD against POST /v2/session/users/sign_in is supported per prompt spec but unused for konk (no custom auth surface).",
+      "per_endpoint": {
+        "konk_create": "user_jwt_or_kubeconfig",
+        "konk_get": "user_jwt_or_kubeconfig",
+        "konk_list": "user_jwt_or_kubeconfig",
+        "konk_update": "user_jwt_or_kubeconfig",
+        "konk_patch": "user_jwt_or_kubeconfig",
+        "konk_delete": "user_jwt_or_kubeconfig",
+        "konk_status_get": "user_jwt_or_kubeconfig",
+        "konk_status_patch": "user_jwt_or_kubeconfig",
+        "konkservice_create": "user_jwt_or_kubeconfig",
+        "konkservice_get": "user_jwt_or_kubeconfig",
+        "konkservice_list": "user_jwt_or_kubeconfig",
+        "konkservice_update": "user_jwt_or_kubeconfig",
+        "konkservice_patch": "user_jwt_or_kubeconfig",
+        "konkservice_delete": "user_jwt_or_kubeconfig",
+        "konkservice_status_get": "user_jwt_or_kubeconfig",
+        "etcd_create": "user_jwt_or_kubeconfig",
+        "etcd_get": "user_jwt_or_kubeconfig",
+        "etcd_list": "user_jwt_or_kubeconfig",
+        "etcd_update": "user_jwt_or_kubeconfig",
+        "etcd_patch": "user_jwt_or_kubeconfig",
+        "etcd_delete": "user_jwt_or_kubeconfig",
+        "etcd_status_get": "user_jwt_or_kubeconfig",
+        "operator_metrics": "service_account_token (s2s) bound to metrics ClusterRole via kube-rbac-proxy (conditional)"
+      },
+      "negative_auth_cases": [
+        "Omit Authorization header (expect 401)",
+        "Send Authorization: Bearer invalid (expect 401)",
+        "Send a valid token without RBAC for the resource (expect 403)"
+      ],
+      "no_hardcoded_credentials": true
+    },
+    "data_generation_strategy": {
+      "naming": "All test-created resource names are prefixed with 'AUTO_TEST_' (RFC1123-safe form 'auto-test-') followed by a collision-safe suffix: auto-test-<scenario>-<unix_nano>-<vu_id>-<rand6>. Names are lowercased and trimmed to RFC1123 (max 63 chars).",
+      "namespace": "A dedicated namespace per run: auto-test-konk-<unix_nano>-<vu_id>-<rand6>. Created in setup, deleted in teardown.",
+      "konk_name_constraint": "Konk and KonkService.spec.konk.name MUST end in '-konk' (regex '^.+-konk$'). Generator appends '-konk' suffix automatically.",
+      "scope_value": "Konk.spec.scope is selected from {cluster, namespace}; default 'namespace' to minimize blast radius."
+    },
+    "parallel_execution_safety_notes": [
+      "Each VU uses an independent test namespace generated from unix_nano + VU id, eliminating cross-VU collisions.",
+      "Resource names embed the VU id and a random suffix; never globally shared.",
+      "All mutating requests are gated by an AUTO_TEST_ prefix check before being sent.",
+      "Teardown deletes only resources tagged with the run prefix, so concurrent runs do not interfere.",
+      "Status polling uses bounded retries (max 180s) to avoid runaway loops under contention."
+    ]
+  },
+  "clarifications_required": [],
+  "clarifications_resolved": [
+    {
+      "topic": "Authoritative API spec",
+      "resolution": "Confirmed by user. No custom REST surface; tests target dynamic kube-apiserver endpoints for the three CRDs (konks, konkservices, etcds)."
+    },
+    {
+      "topic": "Target cluster",
+      "resolution": "us-dev-5 confirmed. Verified live: kubectl context teleport.services.sdp.infoblox.com-us-dev-5; konk-operator deployment running in 'konk' namespace; CRDs registered (konks/konkservices/etcds at konk.infoblox.com/v1alpha1)."
+    },
+    {
+      "topic": "Authentication source",
+      "resolution": "Use kubeconfig (Teleport) identity 'rsatal' (group teleport-group:k8s-admin -> cluster-admin equivalent). For K6 either (a) run 'kubectl proxy --port=8001' and set KUBE_API_URL=http://127.0.0.1:8001 (no token), or (b) mint a dedicated ServiceAccount: 'kubectl -n konk create sa konk-smoke-tester' + ClusterRoleBinding to cluster-admin (or a narrower role granting CRUD on konks/konkservices/etcds and namespaces) and 'kubectl -n konk create token konk-smoke-tester --duration=2h' -> KUBE_BEARER_TOKEN. KUBE_API_URL = $(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')."
+    },
+    {
+      "topic": "Etcd CR realism",
+      "resolution": "Use minimal realistic spec mirroring the running bulk-konk-etcd: { statefulset: { replicaCount: 1 }, resources: { limits: { memory: '1Gi' } } }. Empty {} also valid (preserve-unknown-fields)."
+    },
+    {
+      "topic": "KonkService dependencies",
+      "resolution": "Each smoke run MUST create its own scenario-local Konk in its dedicated auto-test namespace. Do NOT reuse the production 'bulk-konk' in the 'aggregate' namespace (it currently hosts 16 live KonkServices across atcapi/ddi/hostapp/ntp/tagging-v2/etc.). Konk template: { scope: 'namespace', etcd: { statefulset: { replicaCount: 1 }, resources: { limits: { memory: '1Gi' } } } }."
+    },
+    {
+      "topic": "Metrics ClusterRole",
+      "resolution": "Conditional. NOT applicable in us-dev-5 (the deployed konk-operator image v0.2.1-175-g1d5d187 has no kube-rbac-proxy sidecar, no metrics Service in the konk namespace, and no args). Scenarios SC-04 and SC-N-07 are kept in the plan but flagged conditional: the K6 implementation must skip them with a printed warning when METRICS_URL/METRICS_TOKEN env vars are unset, so they will exercise the surface automatically in higher environments where it is enabled."
+    },
+    {
+      "topic": "Reconciliation timeout",
+      "resolution": "Increased to 300 seconds (poll interval 5s). Reason regex updated to '^(Install|Upgrade)?Successful$' to match both InstallSuccessful (first reconcile) and UpgradeSuccessful (subsequent reconciles), as observed on bulk-konk."
+    },
+    {
+      "topic": "Helm-operator status semantics (caveat)",
+      "resolution": "The konk-operator is operator-sdk Helm-based. It writes status.conditions[type=Deployed,status=True,reason=Install/UpgradeSuccessful] as soon as 'helm install/upgrade' returns 0; it does NOT gate that condition on downstream pod readiness (image pull, runtime health, dependency availability). The smoke suite therefore validates the operator's externally observable contract (CRD acceptance + reconciliation-success condition), which is the correct boundary for a smoke test. Pod-level health is downstream and out of scope; observed CrashLoopBackOff in pods (e.g. due to environment-specific image/registry issues) does not invalidate the operator-level success signal."
+    },
+    {
+      "topic": "kubectl proxy auth mode",
+      "resolution": "Added KUBE_USE_PROXY=true mode so the suite can be run through 'kubectl proxy --port=8001' using the caller's kubeconfig identity (default in dev / Teleport contexts). When set, the suite (a) suppresses Authorization headers (proxy forwards them verbatim and they would 401), (b) skips SC-N-03 with a structured warning (proxy injects identity, so unauth cannot be exercised through it)."
+    }
+  ],
+  "implementation": {
+    "language": "K6 JavaScript (k6 v1.7.x)",
+    "file_layout": {
+      "smoke-tests/main.js": "Entry point: options, setup() (cluster allowlist + auth + namespace), default() (orchestrates SC-01..SC-04, SC-N-01..SC-N-07 with per-scenario try/catch + inline cleanup), teardown() (namespace delete + bounded poll for 404).",
+      "smoke-tests/config/config.js": "Env-driven config: ALLOWED_CLUSTERS, TARGET_CLUSTER, KUBE_API_URL, KUBE_BEARER_TOKEN, KUBE_USE_PROXY, KUBE_INSECURE_SKIP_TLS_VERIFY, AUTH_MODE, BASE_URL, USER_EMAIL/PASSWORD, METRICS_URL/METRICS_TOKEN, RECONCILE_TIMEOUT_S=300, POLL_INTERVAL_S=5, DEPLOYED_REASON_REGEX, API_GROUP, API_VERSION, URL builders (u.konks/konk/konkStatus/konkservices/konkservice/konkserviceStatus/etcds/etcd/namespace/namespaces).",
+      "smoke-tests/helpers/utils.js": "parseBody, logRequest (Authorization redacted; '<omitted: kubectl proxy>' label when KUBE_USE_PROXY), logSkip, safeBody, rand6, uniqueSuffix, autoTestName, autoTestNamespace, kget/kpost/kput/kpatch/kdelete (always-log HTTP wrappers; suppress Authorization in proxy mode), pollDeployed, pollDeleted.",
+      "smoke-tests/helpers/validators.js": "Status validators (isOk/isCreated/isAccepted/isNotFound/isUnauthorized/isForbidden/isClientError/isInvalid), body validators (hasId, hasResultsArray, hasNoError, bodyFieldEquals, metadataFieldEquals, hasAllowedBoolean, isPromExposition).",
+      "smoke-tests/helpers/resourceHelpers.js": "AUTO_TEST_PREFIX guard (isAutoTestResource, ensureAutoTest, safeDelete), resourceExists, resourceDeleted.",
+      "smoke-tests/helpers/auth.js": "authToken() returns kube bearer (default) or '' (proxy mode) or jwtSignIn() (AUTH_MODE=jwt).",
+      "smoke-tests/tests/sc01_konk_lifecycle.test.js": "SC-01",
+      "smoke-tests/tests/sc02_konkservice_lifecycle.test.js": "SC-02 (creates its own parent Konk)",
+      "smoke-tests/tests/sc03_etcd_lifecycle.test.js": "SC-03",
+      "smoke-tests/tests/sc04_metrics_reachable.test.js": "SC-04 (conditional on METRICS_URL/METRICS_TOKEN)",
+      "smoke-tests/tests/scN01_reject_invalid_scope.test.js": "SC-N-01",
+      "smoke-tests/tests/scN02_reject_konkservice_invalid.test.js": "SC-N-02",
+      "smoke-tests/tests/scN03_reject_unauth_create.test.js": "SC-N-03 (conditional skip when KUBE_USE_PROXY=true)",
+      "smoke-tests/tests/scN04_get_missing_404.test.js": "SC-N-04",
+      "smoke-tests/tests/scN05_delete_missing_404.test.js": "SC-N-05",
+      "smoke-tests/tests/scN06_reject_missing_namespace.test.js": "SC-N-06",
+      "smoke-tests/tests/scN07_metrics_unauth.test.js": "SC-N-07 (conditional on METRICS_URL)",
+      "smoke-tests/run.sh": "Self-contained runner. Picks a free local port (or honors PORT), starts 'kubectl proxy --address=127.0.0.1 --accept-hosts=^127\\.0\\.0\\.1$', waits for /readyz, runs k6 with KUBE_USE_PROXY=true, and ALWAYS kills the proxy on exit (trap EXIT INT TERM). Forwards METRICS_URL/METRICS_TOKEN/RECONCILE_TIMEOUT_S/POLL_INTERVAL_S/KUBE_INSECURE_SKIP_TLS_VERIFY/ALLOWED_CLUSTERS to k6."
+    },
+    "required_env_vars": {
+      "required": ["KUBE_API_URL", "TARGET_CLUSTER (must be in ALLOWED_CLUSTERS, default 'us-dev-5')"],
+      "required_one_of": ["KUBE_BEARER_TOKEN (default mode) OR KUBE_USE_PROXY=true (proxy mode)"],
+      "optional": ["ALLOWED_CLUSTERS (comma-separated; default 'us-dev-5')", "KUBE_INSECURE_SKIP_TLS_VERIFY (default false)", "AUTH_MODE (kube|jwt; default kube)", "BASE_URL, USER_EMAIL, USER_PASSWORD (jwt mode only)", "METRICS_URL, METRICS_TOKEN (enable SC-04 / SC-N-07)", "RECONCILE_TIMEOUT_S (default 300)", "POLL_INTERVAL_S (default 5)"]
+    },
+    "run_commands": {
+      "recommended_wrapper": [
+        "./smoke-tests/run.sh",
+        "# us-dev-5 by default; manages kubectl proxy lifecycle automatically",
+        "TARGET_CLUSTER=us-dev-5 PORT=9000 ./smoke-tests/run.sh",
+        "# pin a specific port",
+        "METRICS_URL=https://… METRICS_TOKEN=… ./smoke-tests/run.sh",
+        "# also runs SC-04 / SC-N-07"
+      ],
+      "via_kubectl_proxy": [
+        "kubectl proxy --port=8001 &",
+        "k6 run smoke-tests/main.js -e KUBE_API_URL=http://127.0.0.1:8001 -e KUBE_USE_PROXY=true -e TARGET_CLUSTER=us-dev-5"
+      ],
+      "via_bearer_token": [
+        "k6 run smoke-tests/main.js -e KUBE_API_URL=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}') -e KUBE_BEARER_TOKEN=$(kubectl -n konk create token konk-smoke-tester --duration=2h) -e TARGET_CLUSTER=us-dev-5"
+      ]
+    }
+  },
+  "last_verified_run": {
+    "date": "2026-05-04",
+    "cluster": "us-dev-5 (teleport.services.sdp.infoblox.com-us-dev-5)",
+    "identity": "rsatal (teleport-group:k8s-admin -> cluster-admin equivalent), via kubectl proxy",
+    "k6_version": "v1.7.1 (darwin/arm64)",
+    "command": "k6 run smoke-tests/main.js -e KUBE_API_URL=http://127.0.0.1:8001 -e KUBE_USE_PROXY=true -e TARGET_CLUSTER=us-dev-5",
+    "duration": "~19s",
+    "checks_total": 42,
+    "checks_succeeded": 42,
+    "checks_failed": 0,
+    "threshold": "checks rate>=0.95 -> 100.00%",
+    "executed_scenarios": ["SC-01", "SC-02", "SC-03", "SC-N-01", "SC-N-02", "SC-N-04", "SC-N-05", "SC-N-06"],
+    "skipped_scenarios": [
+      { "id": "SC-04", "reason": "METRICS_URL or METRICS_TOKEN not provided (conditional)" },
+      { "id": "SC-N-03", "reason": "KUBE_USE_PROXY=true (proxy injects kubeconfig identity)" },
+      { "id": "SC-N-07", "reason": "METRICS_URL not provided (conditional)" }
+    ],
+    "cleanup_outcome": "All AUTO_TEST_ CRs and the dedicated namespace deleted; bulk-konk in the 'aggregate' namespace untouched."
+  }
+}

--- a/smoke-tests/config/config.js
+++ b/smoke-tests/config/config.js
@@ -1,0 +1,62 @@
+// Centralized configuration for konk smoke tests.
+// All values come from environment variables; no credentials hardcoded.
+
+export const ALLOWED_CLUSTERS = (__ENV.ALLOWED_CLUSTERS || 'us-dev-5')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export const TARGET_CLUSTER = (__ENV.TARGET_CLUSTER || 'us-dev-5').trim();
+
+// Kube API
+export const KUBE_API_URL = (__ENV.KUBE_API_URL || '').replace(/\/$/, '');
+export const KUBE_BEARER_TOKEN = __ENV.KUBE_BEARER_TOKEN || '';
+export const KUBE_INSECURE_SKIP_TLS_VERIFY =
+  (__ENV.KUBE_INSECURE_SKIP_TLS_VERIFY || 'false').toLowerCase() === 'true';
+// When true, the kube API is reached through `kubectl proxy` (which uses the
+// caller's kubeconfig identity). In this mode we MUST NOT send Authorization
+// headers because the proxy forwards them verbatim and they will fail auth.
+export const KUBE_USE_PROXY =
+  (__ENV.KUBE_USE_PROXY || 'false').toLowerCase() === 'true';
+
+// Optional generic JWT auth (per prompt spec)
+export const AUTH_MODE = (__ENV.AUTH_MODE || 'kube').toLowerCase(); // 'kube' | 'jwt'
+export const BASE_URL = (__ENV.BASE_URL || '').replace(/\/$/, '');
+export const USER_EMAIL = __ENV.USER_EMAIL || '';
+export const USER_PASSWORD = __ENV.USER_PASSWORD || '';
+
+// Conditional metrics endpoint
+export const METRICS_URL = (__ENV.METRICS_URL || '').replace(/\/$/, '');
+export const METRICS_TOKEN = __ENV.METRICS_TOKEN || '';
+
+// Reconciliation polling (per smoke-test-plan verification_strategy.polling)
+export const RECONCILE_TIMEOUT_S = parseInt(__ENV.RECONCILE_TIMEOUT_S || '300', 10);
+export const POLL_INTERVAL_S = parseInt(__ENV.POLL_INTERVAL_S || '5', 10);
+export const DEPLOYED_REASON_REGEX = /^(Install|Upgrade)?Successful$/;
+
+// CRD coordinates
+export const API_GROUP = 'konk.infoblox.com';
+export const API_VERSION = 'v1alpha1';
+
+// HTTP defaults shared by all calls
+export const HTTP_PARAMS_BASE = {
+  timeout: '60s',
+  insecureSkipTLSVerify: KUBE_INSECURE_SKIP_TLS_VERIFY,
+};
+
+// URL builders
+export function nsBase(ns) {
+  return `${KUBE_API_URL}/apis/${API_GROUP}/${API_VERSION}/namespaces/${ns}`;
+}
+export const u = {
+  konks: (ns) => `${nsBase(ns)}/konks`,
+  konk: (ns, name) => `${nsBase(ns)}/konks/${name}`,
+  konkStatus: (ns, name) => `${nsBase(ns)}/konks/${name}/status`,
+  konkservices: (ns) => `${nsBase(ns)}/konkservices`,
+  konkservice: (ns, name) => `${nsBase(ns)}/konkservices/${name}`,
+  konkserviceStatus: (ns, name) => `${nsBase(ns)}/konkservices/${name}/status`,
+  etcds: (ns) => `${nsBase(ns)}/etcds`,
+  etcd: (ns, name) => `${nsBase(ns)}/etcds/${name}`,
+  namespace: (ns) => `${KUBE_API_URL}/api/v1/namespaces/${ns}`,
+  namespaces: () => `${KUBE_API_URL}/api/v1/namespaces`,
+};

--- a/smoke-tests/helpers/auth.js
+++ b/smoke-tests/helpers/auth.js
@@ -1,0 +1,47 @@
+// Authentication helpers.
+// Kubernetes-bearer-token mode is the default for konk (per smoke-test-plan
+// authentication_strategy). The two-step JWT flow defined in the prompt
+// (POST /v2/session/users/sign_in) is supported when AUTH_MODE=jwt.
+
+import http from 'k6/http';
+import { fail } from 'k6';
+import {
+  AUTH_MODE,
+  KUBE_BEARER_TOKEN,
+  KUBE_USE_PROXY,
+  BASE_URL,
+  USER_EMAIL,
+  USER_PASSWORD,
+} from '../config/config.js';
+import { logRequest, parseBody } from './utils.js';
+
+export function jwtSignIn() {
+  if (!BASE_URL || !USER_EMAIL || !USER_PASSWORD) {
+    fail('AUTH_MODE=jwt requires BASE_URL, USER_EMAIL, USER_PASSWORD');
+  }
+  const url = `${BASE_URL}/v2/session/users/sign_in`;
+  const payload = JSON.stringify({ email: USER_EMAIL, password: USER_PASSWORD });
+  const resp = http.post(url, payload, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '30s',
+  });
+  logRequest('setup', 'jwt_sign_in', 'POST', url, { email: USER_EMAIL, password: '***' }, resp);
+  if (resp.status < 200 || resp.status >= 300) {
+    fail(`JWT sign-in failed: status=${resp.status}`);
+  }
+  const b = parseBody(resp);
+  const token = b.access_token || b.token || b.jwt;
+  if (!token) fail('JWT sign-in response missing access_token/token/jwt');
+  return token;
+}
+
+// Returns the bearer token to use for kube-apiserver calls.
+export function authToken() {
+  if (AUTH_MODE === 'jwt') return jwtSignIn();
+  // When using `kubectl proxy`, identity comes from kubeconfig, not a token.
+  if (KUBE_USE_PROXY) return '';
+  if (!KUBE_BEARER_TOKEN) {
+    fail('KUBE_BEARER_TOKEN is required when AUTH_MODE=kube (default). Set KUBE_USE_PROXY=true if going through `kubectl proxy`.');
+  }
+  return KUBE_BEARER_TOKEN;
+}

--- a/smoke-tests/helpers/resourceHelpers.js
+++ b/smoke-tests/helpers/resourceHelpers.js
@@ -1,0 +1,48 @@
+// Resource lifecycle and AUTO_TEST_ guard helpers.
+import { fail, check } from 'k6';
+import { parseBody, kdelete, logRequest } from './utils.js';
+
+// AUTO_TEST guard. K8s names must be RFC1123 lowercase, so the prefix is the
+// equivalent lowercased form 'auto-test-'.
+export const AUTO_TEST_PREFIX = 'auto-test-';
+
+export const isAutoTestResource = (value) =>
+  typeof value === 'string' && value.startsWith(AUTO_TEST_PREFIX);
+
+// Hard guard: refuse to mutate non-AUTO_TEST resources.
+export function ensureAutoTest(name, op, endpointName) {
+  if (!isAutoTestResource(name)) {
+    fail(
+      `GUARDRAIL VIOLATION: refusing ${op} on '${name}' for endpoint '${endpointName}'. ` +
+        `Only resources prefixed '${AUTO_TEST_PREFIX}' may be mutated.`,
+    );
+  }
+}
+
+// Post-create / get validators
+export const resourceExists = (getResponse, idField, expectedId) =>
+  ((parseBody(getResponse).metadata) || {})[idField] === expectedId;
+
+export const resourceDeleted = (getResponse) =>
+  getResponse.status === 404 || (parseBody(getResponse).items || []).length === 0;
+
+// Safe delete that respects the AUTO_TEST_ guard. Used in cleanup.
+export function safeDelete(token, url, endpointName, name) {
+  if (!isAutoTestResource(name)) {
+    console.log(
+      JSON.stringify({
+        phase: 'cleanup',
+        endpoint: endpointName,
+        skipped: true,
+        reason: `name '${name}' missing ${AUTO_TEST_PREFIX} prefix`,
+      }),
+    );
+    return null;
+  }
+  const r = kdelete(token, url, endpointName);
+  check(r, {
+    [`${endpointName} delete 2xx/404`]: (resp) =>
+      resp.status === 200 || resp.status === 202 || resp.status === 404,
+  });
+  return r;
+}

--- a/smoke-tests/helpers/utils.js
+++ b/smoke-tests/helpers/utils.js
@@ -1,0 +1,152 @@
+// Common utilities: parsing, logging, naming, polling.
+import { sleep } from 'k6';
+import http from 'k6/http';
+import {
+  HTTP_PARAMS_BASE,
+  RECONCILE_TIMEOUT_S,
+  POLL_INTERVAL_S,
+  DEPLOYED_REASON_REGEX,
+  KUBE_USE_PROXY,
+} from '../config/config.js';
+
+// ---- Parsing ----
+export const parseBody = (r) => {
+  try {
+    return JSON.parse(r.body);
+  } catch (e) {
+    return {};
+  }
+};
+
+// ---- Logging ----
+export function logRequest(phase, endpoint, method, url, payload, response) {
+  let bodyOut = '';
+  try {
+    bodyOut = response && response.body ? String(response.body) : '';
+    if (bodyOut.length > 2000) bodyOut = bodyOut.slice(0, 2000) + '...[truncated]';
+  } catch (e) {
+    bodyOut = '';
+  }
+  const reqHeaders = KUBE_USE_PROXY
+    ? { Authorization: '<omitted: kubectl proxy>' }
+    : { Authorization: 'Bearer ***redacted***' };
+  console.log(
+    JSON.stringify({
+      phase,
+      endpoint,
+      method,
+      url,
+      requestHeaders: reqHeaders,
+      requestPayload: payload || null,
+      status: response ? response.status : null,
+      responseBody: bodyOut,
+    }),
+  );
+}
+
+export function logSkip(scenarioId, endpoint, reason) {
+  console.log(
+    JSON.stringify({ phase: 'execution', scenario: scenarioId, endpoint, skipped: true, reason }),
+  );
+}
+
+export function safeBody(body) {
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch (e) {
+    return String(body).slice(0, 500);
+  }
+}
+
+// ---- Naming (RFC1123-safe AUTO_TEST_ form) ----
+export function rand6() {
+  return Math.random().toString(36).slice(2, 8);
+}
+export function uniqueSuffix(scenarioId) {
+  return `${scenarioId.toLowerCase()}-${Date.now()}-${__VU}-${rand6()}`;
+}
+function rfc1123(name) {
+  let n = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  if (n.length > 63) n = n.slice(0, 63).replace(/-$/, '');
+  return n;
+}
+export function autoTestName(scenarioId, hint) {
+  return rfc1123(`auto-test-${hint || ''}-${uniqueSuffix(scenarioId)}`);
+}
+export function autoTestNamespace() {
+  return rfc1123(`auto-test-konk-${Date.now()}-${__VU}-${rand6()}`);
+}
+
+// ---- HTTP wrappers (always log) ----
+function withHeaders(token, extra = {}) {
+  const baseHeaders = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  // Suppress Authorization when going through `kubectl proxy` (it uses the
+  // caller's kubeconfig identity and forwards any Authorization header verbatim).
+  if (!KUBE_USE_PROXY && token) baseHeaders.Authorization = `Bearer ${token}`;
+  return Object.assign(
+    {},
+    HTTP_PARAMS_BASE,
+    { headers: Object.assign(baseHeaders, extra.headers || {}) },
+    extra,
+  );
+}
+
+export function kget(token, url, endpointName) {
+  const r = http.get(url, withHeaders(token));
+  logRequest('execution', endpointName, 'GET', url, null, r);
+  return r;
+}
+export function kpost(token, url, body, endpointName) {
+  const r = http.post(url, body, withHeaders(token));
+  logRequest('execution', endpointName, 'POST', url, safeBody(body), r);
+  return r;
+}
+export function kput(token, url, body, endpointName) {
+  const r = http.put(url, body, withHeaders(token));
+  logRequest('execution', endpointName, 'PUT', url, safeBody(body), r);
+  return r;
+}
+export function kpatch(token, url, body, endpointName, contentType = 'application/merge-patch+json') {
+  const r = http.patch(url, body, withHeaders(token, { headers: { 'Content-Type': contentType } }));
+  logRequest('execution', endpointName, 'PATCH', url, safeBody(body), r);
+  return r;
+}
+export function kdelete(token, url, endpointName) {
+  const r = http.del(url, null, withHeaders(token));
+  logRequest('execution', endpointName, 'DELETE', url, null, r);
+  return r;
+}
+
+// ---- Polling ----
+export function pollDeployed(token, getUrl, endpointName) {
+  const deadline = Date.now() + RECONCILE_TIMEOUT_S * 1000;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = kget(token, getUrl, endpointName);
+    if (last.status === 200) {
+      const body = parseBody(last);
+      const conds = (body.status && body.status.conditions) || [];
+      const deployed = conds.find((c) => c.type === 'Deployed');
+      if (deployed && deployed.status === 'True' && DEPLOYED_REASON_REGEX.test(deployed.reason || '')) {
+        return { ok: true, response: last, condition: deployed };
+      }
+    }
+    sleep(POLL_INTERVAL_S);
+  }
+  return { ok: false, response: last };
+}
+
+export function pollDeleted(token, getUrl, endpointName) {
+  const deadline = Date.now() + RECONCILE_TIMEOUT_S * 1000;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = kget(token, getUrl, endpointName);
+    if (last.status === 404) return { ok: true, response: last };
+    sleep(POLL_INTERVAL_S);
+  }
+  return { ok: false, response: last };
+}

--- a/smoke-tests/helpers/validators.js
+++ b/smoke-tests/helpers/validators.js
@@ -1,0 +1,37 @@
+// Reusable validation helpers used inside k6 check().
+import { parseBody } from './utils.js';
+
+// ---- Status validators ----
+export const isOk = (r) => r.status === 200;
+export const isCreated = (r) => r.status === 200 || r.status === 201;
+export const isAccepted = (r) => r.status === 200 || r.status === 202;
+export const isNotFound = (r) => r.status === 404;
+export const isUnauthorized = (r) => r.status === 401;
+export const isForbidden = (r) => r.status === 403;
+export const isClientError = (r) => r.status >= 400 && r.status < 500;
+export const isInvalid = (r) => r.status === 400 || r.status === 422;
+
+// ---- Common body validators ----
+// For Kubernetes objects: id == metadata.uid
+export const hasId = (r) => {
+  const b = parseBody(r);
+  const uid = b && b.metadata && b.metadata.uid;
+  return typeof uid === 'string' && uid.length > 0;
+};
+// For Kubernetes lists: items array
+export const hasResultsArray = (r) => Array.isArray(parseBody(r).items);
+
+export const hasNoError = (r) => {
+  const b = parseBody(r);
+  // Kubernetes errors come as kind=Status,status=Failure
+  return !(b && b.kind === 'Status' && b.status === 'Failure');
+};
+
+export const bodyFieldEquals = (field, expected) => (r) => parseBody(r)[field] === expected;
+export const metadataFieldEquals = (field, expected) => (r) =>
+  ((parseBody(r).metadata) || {})[field] === expected;
+
+export const hasAllowedBoolean = (r) => typeof parseBody(r).allowed === 'boolean';
+
+export const isPromExposition = (r) =>
+  typeof r.body === 'string' && (/^# HELP /m.test(r.body) || /^# TYPE /m.test(r.body));

--- a/smoke-tests/main.js
+++ b/smoke-tests/main.js
@@ -1,0 +1,137 @@
+// k6 smoke test entry point for konk.
+// Orchestrates setup -> scenarios -> teardown with strict AUTO_TEST_ guardrails.
+
+import { check, fail } from 'k6';
+import {
+  ALLOWED_CLUSTERS,
+  TARGET_CLUSTER,
+  KUBE_API_URL,
+  u,
+  API_GROUP,
+  API_VERSION,
+} from './config/config.js';
+import {
+  autoTestNamespace,
+  kpost,
+  kget,
+  kdelete,
+  pollDeleted,
+} from './helpers/utils.js';
+import { authToken } from './helpers/auth.js';
+import { safeDelete } from './helpers/resourceHelpers.js';
+
+import { runSC01 } from './tests/sc01_konk_lifecycle.test.js';
+import { runSC02 } from './tests/sc02_konkservice_lifecycle.test.js';
+import { runSC03 } from './tests/sc03_etcd_lifecycle.test.js';
+import { runSC04 } from './tests/sc04_metrics_reachable.test.js';
+import { runSCN01 } from './tests/scN01_reject_invalid_scope.test.js';
+import { runSCN02 } from './tests/scN02_reject_konkservice_invalid.test.js';
+import { runSCN03 } from './tests/scN03_reject_unauth_create.test.js';
+import { runSCN04 } from './tests/scN04_get_missing_404.test.js';
+import { runSCN05 } from './tests/scN05_delete_missing_404.test.js';
+import { runSCN06 } from './tests/scN06_reject_missing_namespace.test.js';
+import { runSCN07 } from './tests/scN07_metrics_unauth.test.js';
+
+export const options = {
+  scenarios: {
+    smoke: { executor: 'per-vu-iterations', vus: 1, iterations: 1, maxDuration: '20m' },
+  },
+  setupTimeout: '2m',
+  teardownTimeout: '5m',
+  thresholds: { checks: ['rate>=0.95'] },
+};
+
+// ---------- setup ----------
+export function setup() {
+  console.log(JSON.stringify({ phase: 'setup', step: 'cluster_allowlist_check', cluster: TARGET_CLUSTER, allowed: ALLOWED_CLUSTERS }));
+  if (!ALLOWED_CLUSTERS.includes(TARGET_CLUSTER)) {
+    fail(`TARGET_CLUSTER='${TARGET_CLUSTER}' is not in ALLOWED_CLUSTERS=${JSON.stringify(ALLOWED_CLUSTERS)}`);
+  }
+  if (!KUBE_API_URL) fail('KUBE_API_URL is required');
+
+  const token = authToken();
+
+  // Connectivity probe: list konks at cluster scope (any-ns) by hitting /apis discovery.
+  const probeUrl = `${KUBE_API_URL}/apis/${API_GROUP}/${API_VERSION}`;
+  const probe = kget(token, probeUrl, 'apigroup_discovery');
+  check(probe, { 'setup: konk apigroup reachable': (r) => r.status === 200 });
+  if (probe.status !== 200) {
+    fail(`setup: cannot reach ${API_GROUP}/${API_VERSION} discovery (status=${probe.status})`);
+  }
+
+  // Create dedicated AUTO_TEST namespace
+  const ns = autoTestNamespace();
+  const nsBody = JSON.stringify({
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: { name: ns, labels: { 'auto-test': 'true' } },
+  });
+  const created = kpost(token, u.namespaces(), nsBody, 'namespace_create');
+  check(created, { 'setup: namespace created (201)': (r) => r.status === 201 });
+  if (created.status !== 201) {
+    fail(`setup: failed to create namespace '${ns}' (status=${created.status})`);
+  }
+
+  return { token, ns };
+}
+
+// ---------- default ----------
+export default function (data) {
+  const ctx = {
+    token: data.token,
+    ns: data.ns,
+    created: { konks: [], konkservices: [], etcds: [] },
+  };
+
+  // Wrap in try/finally so inline cleanup always runs, even if a scenario
+  // throws an uncaught error. teardown() is the second safety net (namespace).
+  try {
+    // Positive
+    try { runSC01(ctx); } catch (e) { console.log(`SC-01 threw: ${e}`); }
+    try { runSC02(ctx); } catch (e) { console.log(`SC-02 threw: ${e}`); }
+    try { runSC03(ctx); } catch (e) { console.log(`SC-03 threw: ${e}`); }
+    try { runSC04(ctx); } catch (e) { console.log(`SC-04 threw: ${e}`); }
+
+    // Negative
+    try { runSCN01(ctx); } catch (e) { console.log(`SC-N-01 threw: ${e}`); }
+    try { runSCN02(ctx); } catch (e) { console.log(`SC-N-02 threw: ${e}`); }
+    try { runSCN03(ctx); } catch (e) { console.log(`SC-N-03 threw: ${e}`); }
+    try { runSCN04(ctx); } catch (e) { console.log(`SC-N-04 threw: ${e}`); }
+    try { runSCN05(ctx); } catch (e) { console.log(`SC-N-05 threw: ${e}`); }
+    try { runSCN06(ctx); } catch (e) { console.log(`SC-N-06 threw: ${e}`); }
+    try { runSCN07(ctx); } catch (e) { console.log(`SC-N-07 threw: ${e}`); }
+  } finally {
+    // Inline cleanup of CRs created during this iteration. Order: KonkService -> Etcd -> Konk.
+    inlineCleanup(ctx);
+  }
+}
+
+function inlineCleanup(ctx) {
+  console.log(JSON.stringify({ phase: 'cleanup', step: 'cr_cleanup_start', namespace: ctx.ns, created: ctx.created }));
+  for (const name of ctx.created.konkservices) {
+    safeDelete(ctx.token, u.konkservice(ctx.ns, name), 'konkservice_delete', name);
+  }
+  for (const name of ctx.created.etcds) {
+    safeDelete(ctx.token, u.etcd(ctx.ns, name), 'etcd_delete', name);
+  }
+  for (const name of ctx.created.konks) {
+    safeDelete(ctx.token, u.konk(ctx.ns, name), 'konk_delete', name);
+  }
+}
+
+// ---------- teardown ----------
+export function teardown(data) {
+  if (!data || !data.ns) return;
+  const ns = data.ns;
+  if (!ns.startsWith('auto-test-')) {
+    console.log(JSON.stringify({ phase: 'teardown', skipped: true, reason: `namespace '${ns}' missing auto-test- prefix` }));
+    return;
+  }
+  console.log(JSON.stringify({ phase: 'teardown', step: 'namespace_delete', namespace: ns }));
+  const r = kdelete(data.token, u.namespace(ns), 'namespace_delete');
+  check(r, {
+    'teardown: namespace delete 2xx/404': (resp) => resp.status === 200 || resp.status === 202 || resp.status === 404,
+  });
+  // Best-effort wait for namespace removal so residual CRs are GC'd.
+  pollDeleted(data.token, u.namespace(ns), 'namespace_get_after_delete');
+}

--- a/smoke-tests/run.sh
+++ b/smoke-tests/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Self-contained smoke runner.
+# Starts `kubectl proxy` on a free port, runs the k6 suite against it, and
+# always cleans up the proxy on exit (success, failure, or Ctrl-C).
+#
+# Usage:
+#   ./smoke-tests/run.sh                       # default: TARGET_CLUSTER=us-dev-5
+#   TARGET_CLUSTER=us-dev-5 ./smoke-tests/run.sh
+#   PORT=8765 ./smoke-tests/run.sh             # use a specific port
+#   K6_BIN=/opt/homebrew/bin/k6 ./smoke-tests/run.sh
+#
+# Pass-through env vars (forwarded to k6):
+#   ALLOWED_CLUSTERS, METRICS_URL, METRICS_TOKEN, RECONCILE_TIMEOUT_S,
+#   POLL_INTERVAL_S, KUBE_INSECURE_SKIP_TLS_VERIFY
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIN_JS="${SCRIPT_DIR}/main.js"
+K6_BIN="${K6_BIN:-k6}"
+TARGET_CLUSTER="${TARGET_CLUSTER:-us-dev-5}"
+ALLOWED_CLUSTERS="${ALLOWED_CLUSTERS:-${TARGET_CLUSTER}}"
+PORT="${PORT:-}"
+
+command -v kubectl >/dev/null || { echo "kubectl not found in PATH" >&2; exit 127; }
+command -v "${K6_BIN}" >/dev/null || { echo "k6 not found (set K6_BIN)" >&2; exit 127; }
+[[ -f "${MAIN_JS}" ]] || { echo "main.js not found at ${MAIN_JS}" >&2; exit 1; }
+
+# Verify cluster context is in the allowlist BEFORE we touch the cluster.
+CTX="$(kubectl config current-context 2>/dev/null || true)"
+if [[ -z "${CTX}" ]]; then
+  echo "no current kube-context" >&2; exit 1
+fi
+if ! grep -q -- "${TARGET_CLUSTER}" <<< "${CTX}"; then
+  echo "WARNING: current kube-context '${CTX}' does not contain TARGET_CLUSTER='${TARGET_CLUSTER}'" >&2
+fi
+
+# Pick a free port if not provided.
+if [[ -z "${PORT}" ]]; then
+  PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+fi
+
+PROXY_LOG="$(mktemp -t konk-smoke-proxy.XXXXXX.log)"
+PROXY_PID=""
+
+cleanup() {
+  local rc=$?
+  if [[ -n "${PROXY_PID}" ]] && kill -0 "${PROXY_PID}" 2>/dev/null; then
+    echo "[run.sh] stopping kubectl proxy (pid=${PROXY_PID})"
+    kill "${PROXY_PID}" 2>/dev/null || true
+    wait "${PROXY_PID}" 2>/dev/null || true
+  fi
+  rm -f "${PROXY_LOG}" 2>/dev/null || true
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[run.sh] starting kubectl proxy on 127.0.0.1:${PORT} (context=${CTX})"
+kubectl proxy --port="${PORT}" --address=127.0.0.1 --accept-hosts='^127\.0\.0\.1$' \
+  >"${PROXY_LOG}" 2>&1 &
+PROXY_PID=$!
+
+# Wait for proxy to become reachable (max 10s).
+for i in $(seq 1 50); do
+  if curl -sf "http://127.0.0.1:${PORT}/readyz" >/dev/null 2>&1 \
+     || curl -sf "http://127.0.0.1:${PORT}/api" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+  if ! kill -0 "${PROXY_PID}" 2>/dev/null; then
+    echo "[run.sh] kubectl proxy exited prematurely. Log:" >&2
+    cat "${PROXY_LOG}" >&2
+    exit 1
+  fi
+done
+
+echo "[run.sh] proxy ready -> http://127.0.0.1:${PORT}"
+echo "[run.sh] running k6 ..."
+
+"${K6_BIN}" run "${MAIN_JS}" \
+  -e "KUBE_API_URL=http://127.0.0.1:${PORT}" \
+  -e "KUBE_USE_PROXY=true" \
+  -e "TARGET_CLUSTER=${TARGET_CLUSTER}" \
+  -e "ALLOWED_CLUSTERS=${ALLOWED_CLUSTERS}" \
+  ${METRICS_URL:+-e "METRICS_URL=${METRICS_URL}"} \
+  ${METRICS_TOKEN:+-e "METRICS_TOKEN=${METRICS_TOKEN}"} \
+  ${RECONCILE_TIMEOUT_S:+-e "RECONCILE_TIMEOUT_S=${RECONCILE_TIMEOUT_S}"} \
+  ${POLL_INTERVAL_S:+-e "POLL_INTERVAL_S=${POLL_INTERVAL_S}"} \
+  ${KUBE_INSECURE_SKIP_TLS_VERIFY:+-e "KUBE_INSECURE_SKIP_TLS_VERIFY=${KUBE_INSECURE_SKIP_TLS_VERIFY}"}

--- a/smoke-tests/tests/sc01_konk_lifecycle.test.js
+++ b/smoke-tests/tests/sc01_konk_lifecycle.test.js
@@ -1,0 +1,55 @@
+// SC-01: Konk CR full lifecycle (create -> get -> list -> patch -> status -> delete)
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost, kget, kpatch, parseBody, pollDeployed } from '../helpers/utils.js';
+import { isCreated, isOk, hasId, hasNoError, hasResultsArray, metadataFieldEquals } from '../helpers/validators.js';
+import { ensureAutoTest, resourceExists } from '../helpers/resourceHelpers.js';
+
+export function runSC01(ctx) {
+  const sid = 'SC-01';
+  // Konk name must end in '-konk' to satisfy the KonkService konk.name regex if reused.
+  const name = autoTestName(sid, 'konk') + '-konk';
+  const body = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Konk',
+    metadata: { name, namespace: ctx.ns, labels: { 'auto-test': 'true' } },
+    spec: { scope: 'namespace' },
+  });
+
+  // CREATE
+  const c = kpost(ctx.token, u.konks(ctx.ns), body, 'konk_create');
+  check(c, {
+    'SC-01 konk_create 201': isCreated,
+    'SC-01 konk_create has uid': hasId,
+    'SC-01 konk_create no error': hasNoError,
+    'SC-01 konk_create name matches': metadataFieldEquals('name', name),
+  });
+  if (!isCreated(c)) return;
+  ctx.created.konks.push(name);
+
+  // GET
+  const g = kget(ctx.token, u.konk(ctx.ns, name), 'konk_get');
+  check(g, {
+    'SC-01 konk_get 200': isOk,
+    'SC-01 konk_get exists': (r) => resourceExists(r, 'name', name),
+  });
+
+  // LIST
+  const l = kget(ctx.token, u.konks(ctx.ns), 'konk_list');
+  check(l, {
+    'SC-01 konk_list 200': isOk,
+    'SC-01 konk_list items[]': hasResultsArray,
+  });
+
+  // PATCH
+  ensureAutoTest(name, 'PATCH', 'konk_patch');
+  const patchBody = JSON.stringify({ metadata: { labels: { 'auto-test-patched': 'true' } } });
+  const p = kpatch(ctx.token, u.konk(ctx.ns, name), patchBody, 'konk_patch');
+  check(p, { 'SC-01 konk_patch 200': isOk });
+
+  // STATUS poll (Deployed=True, reason ~ /^(Install|Upgrade)?Successful$/)
+  const polled = pollDeployed(ctx.token, u.konk(ctx.ns, name), 'konk_status_get');
+  check(polled, {
+    'SC-01 konk reaches Deployed=True with Successful reason': (x) => x.ok === true,
+  });
+}

--- a/smoke-tests/tests/sc02_konkservice_lifecycle.test.js
+++ b/smoke-tests/tests/sc02_konkservice_lifecycle.test.js
@@ -1,0 +1,74 @@
+// SC-02: KonkService CR full lifecycle. Creates its own parent Konk per plan.
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost, kget, kpatch, pollDeployed } from '../helpers/utils.js';
+import { isCreated, isOk, hasId, hasResultsArray, metadataFieldEquals } from '../helpers/validators.js';
+import { ensureAutoTest } from '../helpers/resourceHelpers.js';
+
+export function runSC02(ctx) {
+  const sid = 'SC-02';
+
+  // Parent Konk
+  const konkName = autoTestName(sid, 'parent') + '-konk';
+  const konkBody = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Konk',
+    metadata: { name: konkName, namespace: ctx.ns, labels: { 'auto-test': 'true' } },
+    spec: { scope: 'namespace' },
+  });
+  const k = kpost(ctx.token, u.konks(ctx.ns), konkBody, 'konk_create');
+  check(k, { 'SC-02 parent konk_create 201': isCreated });
+  if (!isCreated(k)) return;
+  ctx.created.konks.push(konkName);
+
+  // KonkService
+  const ksName = autoTestName(sid, 'ks');
+  const ksBody = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'KonkService',
+    metadata: { name: ksName, namespace: ctx.ns, labels: { 'auto-test': 'true' } },
+    spec: {
+      group: {
+        name: 'auto-test.example.com',
+        kinds: ['AutoTestThing'],
+        verbs: ['create', 'get', 'list', 'delete'],
+      },
+      konk: { name: konkName },
+      service: { name: ksName },
+      version: 'v1alpha1',
+    },
+  });
+  const c = kpost(ctx.token, u.konkservices(ctx.ns), ksBody, 'konkservice_create');
+  check(c, {
+    'SC-02 konkservice_create 201': isCreated,
+    'SC-02 konkservice_create has uid': hasId,
+  });
+  if (!isCreated(c)) return;
+  ctx.created.konkservices.push(ksName);
+
+  // GET
+  const g = kget(ctx.token, u.konkservice(ctx.ns, ksName), 'konkservice_get');
+  check(g, {
+    'SC-02 konkservice_get 200': isOk,
+    'SC-02 konkservice_get name matches': metadataFieldEquals('name', ksName),
+  });
+
+  // LIST
+  const l = kget(ctx.token, u.konkservices(ctx.ns), 'konkservice_list');
+  check(l, {
+    'SC-02 konkservice_list 200': isOk,
+    'SC-02 konkservice_list items[]': hasResultsArray,
+  });
+
+  // PATCH (label only)
+  ensureAutoTest(ksName, 'PATCH', 'konkservice_patch');
+  const patchBody = JSON.stringify({ metadata: { labels: { 'auto-test-patched': 'true' } } });
+  const p = kpatch(ctx.token, u.konkservice(ctx.ns, ksName), patchBody, 'konkservice_patch');
+  check(p, { 'SC-02 konkservice_patch 200': isOk });
+
+  // STATUS poll
+  const polled = pollDeployed(ctx.token, u.konkservice(ctx.ns, ksName), 'konkservice_status_get');
+  check(polled, {
+    'SC-02 konkservice reaches Deployed=True with Successful reason': (x) => x.ok === true,
+  });
+}

--- a/smoke-tests/tests/sc03_etcd_lifecycle.test.js
+++ b/smoke-tests/tests/sc03_etcd_lifecycle.test.js
@@ -1,0 +1,37 @@
+// SC-03: Etcd CR create/get/list/delete (delete handled in teardown).
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost, kget } from '../helpers/utils.js';
+import { isCreated, isOk, hasId, hasResultsArray } from '../helpers/validators.js';
+
+export function runSC03(ctx) {
+  const sid = 'SC-03';
+  const name = autoTestName(sid, 'etcd');
+  const body = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Etcd',
+    metadata: { name, namespace: ctx.ns, labels: { 'auto-test': 'true' } },
+    // Minimal-but-realistic spec mirroring bulk-konk-etcd in us-dev-5.
+    spec: {
+      statefulset: { replicaCount: 1 },
+      resources: { limits: { memory: '1Gi' } },
+    },
+  });
+
+  const c = kpost(ctx.token, u.etcds(ctx.ns), body, 'etcd_create');
+  check(c, {
+    'SC-03 etcd_create 201': isCreated,
+    'SC-03 etcd_create has uid': hasId,
+  });
+  if (!isCreated(c)) return;
+  ctx.created.etcds.push(name);
+
+  const g = kget(ctx.token, u.etcd(ctx.ns, name), 'etcd_get');
+  check(g, { 'SC-03 etcd_get 200': isOk });
+
+  const l = kget(ctx.token, u.etcds(ctx.ns), 'etcd_list');
+  check(l, {
+    'SC-03 etcd_list 200': isOk,
+    'SC-03 etcd_list items[]': hasResultsArray,
+  });
+}

--- a/smoke-tests/tests/sc04_metrics_reachable.test.js
+++ b/smoke-tests/tests/sc04_metrics_reachable.test.js
@@ -1,0 +1,26 @@
+// SC-04: Operator metrics endpoint reachable with valid token (CONDITIONAL).
+// Skipped if METRICS_URL or METRICS_TOKEN env vars are unset.
+import http from 'k6/http';
+import { check } from 'k6';
+import { METRICS_URL, METRICS_TOKEN, KUBE_INSECURE_SKIP_TLS_VERIFY } from '../config/config.js';
+import { logRequest, logSkip } from '../helpers/utils.js';
+import { isOk, isPromExposition } from '../helpers/validators.js';
+
+export function runSC04() {
+  const sid = 'SC-04';
+  if (!METRICS_URL || !METRICS_TOKEN) {
+    logSkip(sid, 'operator_metrics', 'METRICS_URL or METRICS_TOKEN not provided (conditional scenario)');
+    return;
+  }
+  const url = METRICS_URL.endsWith('/metrics') ? METRICS_URL : `${METRICS_URL}/metrics`;
+  const r = http.get(url, {
+    headers: { Authorization: `Bearer ${METRICS_TOKEN}` },
+    timeout: '30s',
+    insecureSkipTLSVerify: KUBE_INSECURE_SKIP_TLS_VERIFY,
+  });
+  logRequest('execution', 'operator_metrics', 'GET', url, null, r);
+  check(r, {
+    'SC-04 metrics 200': isOk,
+    'SC-04 metrics is Prometheus exposition': isPromExposition,
+  });
+}

--- a/smoke-tests/tests/scN01_reject_invalid_scope.test.js
+++ b/smoke-tests/tests/scN01_reject_invalid_scope.test.js
@@ -1,0 +1,23 @@
+// SC-N-01: Reject Konk create with invalid spec.scope.
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost, kget } from '../helpers/utils.js';
+import { isClientError, isCreated, isNotFound } from '../helpers/validators.js';
+
+export function runSCN01(ctx) {
+  const sid = 'SC-N-01';
+  const name = autoTestName(sid, 'badscope') + '-konk';
+  const body = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Konk',
+    metadata: { name, namespace: ctx.ns },
+    spec: { scope: 'invalid-scope-value' },
+  });
+  const r = kpost(ctx.token, u.konks(ctx.ns), body, 'konk_create_invalid_scope');
+  check(r, {
+    'SC-N-01 konk_create rejected (4xx)': isClientError,
+    'SC-N-01 not persisted (no 2xx)': (resp) => !isCreated(resp),
+  });
+  const g = kget(ctx.token, u.konk(ctx.ns, name), 'konk_get_after_invalid');
+  check(g, { 'SC-N-01 follow-up GET 404': isNotFound });
+}

--- a/smoke-tests/tests/scN02_reject_konkservice_invalid.test.js
+++ b/smoke-tests/tests/scN02_reject_konkservice_invalid.test.js
@@ -1,0 +1,22 @@
+// SC-N-02: Reject KonkService missing required fields / invalid konk.name pattern.
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost } from '../helpers/utils.js';
+import { isClientError, isCreated } from '../helpers/validators.js';
+
+export function runSCN02(ctx) {
+  const sid = 'SC-N-02';
+  const name = autoTestName(sid, 'badks');
+  const body = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'KonkService',
+    metadata: { name, namespace: ctx.ns },
+    // Missing: group, service, version. konk.name violates ^.+-konk$
+    spec: { konk: { name: 'not-matching-pattern' } },
+  });
+  const r = kpost(ctx.token, u.konkservices(ctx.ns), body, 'konkservice_create_invalid');
+  check(r, {
+    'SC-N-02 konkservice_create rejected (4xx)': isClientError,
+    'SC-N-02 not persisted (no 2xx)': (resp) => !isCreated(resp),
+  });
+}

--- a/smoke-tests/tests/scN03_reject_unauth_create.test.js
+++ b/smoke-tests/tests/scN03_reject_unauth_create.test.js
@@ -1,0 +1,67 @@
+// SC-N-03: Unauthenticated create rejected.
+import http from 'k6/http';
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u, KUBE_INSECURE_SKIP_TLS_VERIFY, KUBE_USE_PROXY } from '../config/config.js';
+import { autoTestName, logRequest, logSkip, safeBody } from '../helpers/utils.js';
+import { isUnauthorized, isForbidden, isClientError } from '../helpers/validators.js';
+
+function postNoAuth(url, body, endpointName) {
+  const r = http.post(url, body, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '30s',
+    insecureSkipTLSVerify: KUBE_INSECURE_SKIP_TLS_VERIFY,
+  });
+  logRequest('execution', endpointName, 'POST', url, safeBody(body), r);
+  return r;
+}
+
+export function runSCN03(ctx) {
+  const sid = 'SC-N-03';
+  if (KUBE_USE_PROXY) {
+    logSkip(sid, 'kube_create_unauth', 'KUBE_USE_PROXY=true: kubectl proxy injects kubeconfig identity, so unauthenticated requests cannot be exercised through it');
+    return;
+  }
+  // Konk
+  const konkName = autoTestName(sid, 'noauth') + '-konk';
+  const konkBody = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Konk',
+    metadata: { name: konkName, namespace: ctx.ns },
+    spec: { scope: 'namespace' },
+  });
+  const r1 = postNoAuth(u.konks(ctx.ns), konkBody, 'konk_create_unauth');
+  check(r1, {
+    'SC-N-03 konk_create unauth rejected': (r) => isUnauthorized(r) || isForbidden(r) || isClientError(r),
+  });
+
+  // KonkService
+  const ksName = autoTestName(sid, 'noauth-ks');
+  const ksBody = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'KonkService',
+    metadata: { name: ksName, namespace: ctx.ns },
+    spec: {
+      group: { name: 'auto-test.example.com', kinds: ['X'], verbs: ['get'] },
+      konk: { name: 'auto-test-noop-konk' },
+      service: { name: ksName },
+      version: 'v1alpha1',
+    },
+  });
+  const r2 = postNoAuth(u.konkservices(ctx.ns), ksBody, 'konkservice_create_unauth');
+  check(r2, {
+    'SC-N-03 konkservice_create unauth rejected': (r) => isUnauthorized(r) || isForbidden(r) || isClientError(r),
+  });
+
+  // Etcd
+  const etcdName = autoTestName(sid, 'noauth-etcd');
+  const etcdBody = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Etcd',
+    metadata: { name: etcdName, namespace: ctx.ns },
+    spec: {},
+  });
+  const r3 = postNoAuth(u.etcds(ctx.ns), etcdBody, 'etcd_create_unauth');
+  check(r3, {
+    'SC-N-03 etcd_create unauth rejected': (r) => isUnauthorized(r) || isForbidden(r) || isClientError(r),
+  });
+}

--- a/smoke-tests/tests/scN04_get_missing_404.test.js
+++ b/smoke-tests/tests/scN04_get_missing_404.test.js
@@ -1,0 +1,21 @@
+// SC-N-04: GET non-existent resources returns 404.
+import { check } from 'k6';
+import { u } from '../config/config.js';
+import { autoTestName, kget } from '../helpers/utils.js';
+import { isNotFound } from '../helpers/validators.js';
+
+export function runSCN04(ctx) {
+  const sid = 'SC-N-04';
+  const k = autoTestName(sid, 'missing') + '-konk';
+  const ks = autoTestName(sid, 'missing-ks');
+  const e = autoTestName(sid, 'missing-etcd');
+
+  const r1 = kget(ctx.token, u.konk(ctx.ns, k), 'konk_get_missing');
+  check(r1, { 'SC-N-04 konk_get missing 404': isNotFound });
+
+  const r2 = kget(ctx.token, u.konkservice(ctx.ns, ks), 'konkservice_get_missing');
+  check(r2, { 'SC-N-04 konkservice_get missing 404': isNotFound });
+
+  const r3 = kget(ctx.token, u.etcd(ctx.ns, e), 'etcd_get_missing');
+  check(r3, { 'SC-N-04 etcd_get missing 404': isNotFound });
+}

--- a/smoke-tests/tests/scN05_delete_missing_404.test.js
+++ b/smoke-tests/tests/scN05_delete_missing_404.test.js
@@ -1,0 +1,12 @@
+// SC-N-05: DELETE non-existent resource returns 404.
+import { check } from 'k6';
+import { u } from '../config/config.js';
+import { autoTestName, kdelete } from '../helpers/utils.js';
+import { isNotFound } from '../helpers/validators.js';
+
+export function runSCN05(ctx) {
+  const sid = 'SC-N-05';
+  const k = autoTestName(sid, 'del-missing') + '-konk';
+  const r = kdelete(ctx.token, u.konk(ctx.ns, k), 'konk_delete_missing');
+  check(r, { 'SC-N-05 konk_delete missing 404': isNotFound });
+}

--- a/smoke-tests/tests/scN06_reject_missing_namespace.test.js
+++ b/smoke-tests/tests/scN06_reject_missing_namespace.test.js
@@ -1,0 +1,22 @@
+// SC-N-06: Reject create in non-existent namespace.
+import { check } from 'k6';
+import { API_GROUP, API_VERSION, u } from '../config/config.js';
+import { autoTestName, kpost } from '../helpers/utils.js';
+import { isClientError, isCreated } from '../helpers/validators.js';
+
+export function runSCN06(ctx) {
+  const sid = 'SC-N-06';
+  const ns = `auto-test-nope-${Date.now()}-${__VU}`;
+  const name = autoTestName(sid, 'badns') + '-konk';
+  const body = JSON.stringify({
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Konk',
+    metadata: { name, namespace: ns },
+    spec: { scope: 'namespace' },
+  });
+  const r = kpost(ctx.token, u.konks(ns), body, 'konk_create_missing_ns');
+  check(r, {
+    'SC-N-06 konk_create in missing ns rejected (4xx)': isClientError,
+    'SC-N-06 not persisted': (resp) => !isCreated(resp),
+  });
+}

--- a/smoke-tests/tests/scN07_metrics_unauth.test.js
+++ b/smoke-tests/tests/scN07_metrics_unauth.test.js
@@ -1,0 +1,33 @@
+// SC-N-07: Operator metrics endpoint without/with-bad token (CONDITIONAL).
+import http from 'k6/http';
+import { check } from 'k6';
+import { METRICS_URL, KUBE_INSECURE_SKIP_TLS_VERIFY } from '../config/config.js';
+import { logRequest, logSkip } from '../helpers/utils.js';
+import { isUnauthorized, isForbidden } from '../helpers/validators.js';
+
+export function runSCN07() {
+  const sid = 'SC-N-07';
+  if (!METRICS_URL) {
+    logSkip(sid, 'operator_metrics', 'METRICS_URL not provided (conditional scenario)');
+    return;
+  }
+  const url = METRICS_URL.endsWith('/metrics') ? METRICS_URL : `${METRICS_URL}/metrics`;
+
+  // No auth
+  const r1 = http.get(url, { timeout: '30s', insecureSkipTLSVerify: KUBE_INSECURE_SKIP_TLS_VERIFY });
+  logRequest('execution', 'operator_metrics_noauth', 'GET', url, null, r1);
+  check(r1, {
+    'SC-N-07 metrics noauth 401/403': (r) => isUnauthorized(r) || isForbidden(r),
+  });
+
+  // Bad token
+  const r2 = http.get(url, {
+    headers: { Authorization: 'Bearer invalid.invalid.invalid' },
+    timeout: '30s',
+    insecureSkipTLSVerify: KUBE_INSECURE_SKIP_TLS_VERIFY,
+  });
+  logRequest('execution', 'operator_metrics_badauth', 'GET', url, null, r2);
+  check(r2, {
+    'SC-N-07 metrics bad token 401/403': (r) => isUnauthorized(r) || isForbidden(r),
+  });
+}


### PR DESCRIPTION
### This PR contains changes for adding the smoke tests and a fix for CI failures

 **### Smoke tests**

- K6 JavaScript suite covering konk operator + apiserver CRUD flows.
- Deterministic, parallel-safe: dynamic collision-free resource names, isolated namespaces.
- Setup → execution → teardown structure; all created resources are cleaned up even on test failure.
- Auth tokens are fetched at setup and injected per request — no hardcoded credentials, env-var driven.
- Verbose request/response logging and explicit HTTP status assertions, so failures are diagnosable from CI logs alone.

<img width="694" height="543" alt="image" src="https://github.com/user-attachments/assets/9ac01de4-e241-4a58-9af4-ef881cf1ef66" />



**### 2. CI fix — upgrade matrix leg**
<img width="810" height="428" alt="image" src="https://github.com/user-attachments/assets/edf5b731-3f9e-49e1-a809-7a692ab68b3b" />

