### PR TITLE
Add weekly architecture agent sync

### DIFF
--- a/.github/workflows/sync-agents.yml
+++ b/.github/workflows/sync-agents.yml
@@ -1,0 +1,28 @@
+name: Sync Architecture Agents
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Monday 6am UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AGENTS_SYNC_APP_ID }}
+          private-key: ${{ secrets.AGENTS_SYNC_APP_KEY }}
+          owner: Infoblox-CTO
+          repositories: architecture-shared-agents
+
+      - uses: Infoblox-CTO/architecture-shared-agents/.github/actions/sync-agents@main
+        with:
+          fetch-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-agents.yml` to enable automated weekly sync of shared architecture agents from [architecture-shared-agents](https://github.com/Infoblox-CTO/architecture-shared-agents).

- Uses org-level secrets `AGENTS_SYNC_APP_ID` / `AGENTS_SYNC_APP_KEY` (already configured org-wide)
- Scheduled for every Monday at 06:00 UTC

## Agents that will be installed

- **docs-revamp** — rewrites docs to meet architecture standards (`/docs-revamp` in Claude Code, `@docs-revamp` in Copilot)
- **docs-evaluate** — evaluates doc quality and coverage (`/docs-evaluate`, `@docs-evaluate`)
- **taxonomy** — enforces consistent naming/taxonomy across the repo (`/taxonomy`, `@taxonomy`)

## After merge

A PR with all agents will be auto-created on this repo, keeping them in sync with the latest versions from `architecture-shared-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)