### PR TITLE
fix(konk-service): use file refs in kubeconfig instead of embedded cert data

### DIFF
--- a/cmd/konk-service/reconcile_kubeconfig.go
+++ b/cmd/konk-service/reconcile_kubeconfig.go
@@ -86,15 +86,18 @@ func reconcileOnce(
 		return
 	}
 
-	// Build a kubeconfig programmatically
+	// Build a kubeconfig with file references (not embedded data).
+	// Consumer pods mount the Secret at a directory (e.g. /etc/kubernetes/).
+	// Using file refs allows client-go to re-read certs from disk on each
+	// TLS handshake, so rotated certs are picked up without pod restart.
 	kubeconfig := clientcmdapi.NewConfig()
 	kubeconfig.Clusters[konkName] = &clientcmdapi.Cluster{
-		Server:                   "https://" + konkFQDN + ":6443",
-		CertificateAuthorityData: caCert,
+		Server:               "https://" + konkFQDN + ":6443",
+		CertificateAuthority: "ca.crt",
 	}
 	kubeconfig.AuthInfos["kubernetes-admin"] = &clientcmdapi.AuthInfo{
-		ClientCertificateData: tlsCert,
-		ClientKeyData:         tlsKey,
+		ClientCertificate: "tls.crt",
+		ClientKey:         "tls.key",
 	}
 	kubeconfig.Contexts[konkName] = &clientcmdapi.Context{
 		Cluster:  konkName,

--- a/cmd/konk-service/reconcile_kubeconfig.go
+++ b/cmd/konk-service/reconcile_kubeconfig.go
@@ -86,26 +86,7 @@ func reconcileOnce(
 		return
 	}
 
-	// Build a kubeconfig with file references (not embedded data).
-	// Consumer pods mount the Secret at a directory (e.g. /etc/kubernetes/).
-	// Using file refs allows client-go to re-read certs from disk on each
-	// TLS handshake, so rotated certs are picked up without pod restart.
-	kubeconfig := clientcmdapi.NewConfig()
-	kubeconfig.Clusters[konkName] = &clientcmdapi.Cluster{
-		Server:               "https://" + konkFQDN + ":6443",
-		CertificateAuthority: "ca.crt",
-	}
-	kubeconfig.AuthInfos["kubernetes-admin"] = &clientcmdapi.AuthInfo{
-		ClientCertificate: "tls.crt",
-		ClientKey:         "tls.key",
-	}
-	kubeconfig.Contexts[konkName] = &clientcmdapi.Context{
-		Cluster:  konkName,
-		AuthInfo: "kubernetes-admin",
-	}
-	kubeconfig.CurrentContext = konkName
-
-	kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
+	kubeconfigBytes, err := buildKubeconfig(konkName, konkFQDN)
 	if err != nil {
 		log.Printf("Error serializing kubeconfig: %v", err)
 		return
@@ -135,6 +116,39 @@ func reconcileOnce(
 	if err != nil {
 		log.Printf("Error reconciling secret: %v", err)
 	}
+}
+
+// buildKubeconfig returns a kubeconfig that references certs by relative file
+// path (ca.crt, tls.crt, tls.key) rather than embedding cert data.
+//
+// This is critical for automatic cert rotation: when client-go sees file-based
+// TLS config, it activates the dynamicClientCert reload mechanism in
+// k8s.io/client-go/transport/cert_rotation.go which re-reads the cert files
+// from disk on every TLS handshake (with a 5-minute refresh). Embedding cert
+// data via ClientCertificateData/ClientKeyData/CertificateAuthorityData
+// disables this mechanism, causing consumers to keep using the expired cert
+// in memory until pod restart.
+//
+// Regression history: the original shell-based reconcile-kubeconfig used file
+// refs (`kubectl config set-credentials --client-certificate tls.crt ...`).
+// The distroless Go rewrite initially embedded cert *data* which broke
+// rotation. See kubeconfig-cert-rotation-options.md (Option 7).
+func buildKubeconfig(konkName, konkFQDN string) ([]byte, error) {
+	kubeconfig := clientcmdapi.NewConfig()
+	kubeconfig.Clusters[konkName] = &clientcmdapi.Cluster{
+		Server:               "https://" + konkFQDN + ":6443",
+		CertificateAuthority: "ca.crt",
+	}
+	kubeconfig.AuthInfos["kubernetes-admin"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: "tls.crt",
+		ClientKey:         "tls.key",
+	}
+	kubeconfig.Contexts[konkName] = &clientcmdapi.Context{
+		Cluster:  konkName,
+		AuthInfo: "kubernetes-admin",
+	}
+	kubeconfig.CurrentContext = konkName
+	return clientcmd.Write(*kubeconfig)
 }
 
 func parseLabels(labelsStr string) map[string]string {

--- a/cmd/konk-service/reconcile_kubeconfig_test.go
+++ b/cmd/konk-service/reconcile_kubeconfig_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TestBuildKubeconfig_UsesFileRefsNotEmbeddedData is the regression test for
+// the cert-rotation bug that caused log errors like:
+//
+//	"Unable to authenticate the request" err="x509: certificate has expired
+//	 or is not yet valid: current time ... is after ..."
+//
+// Root cause: the distroless Go rewrite of reconcile-kubeconfig embedded
+// cert *data* into the kubeconfig (ClientCertificateData/ClientKeyData/
+// CertificateAuthorityData). This disabled client-go's dynamicClientCert
+// reload (which only activates for file-based TLS config), so consumers
+// kept using expired in-memory certs until pod restart.
+//
+// The fix uses relative file references that resolve against the Secret
+// mount directory, restoring the behavior of the original shell script.
+func TestBuildKubeconfig_UsesFileRefsNotEmbeddedData(t *testing.T) {
+	out, err := buildKubeconfig("test-konk", "test-konk.aggregate.svc")
+	if err != nil {
+		t.Fatalf("buildKubeconfig returned error: %v", err)
+	}
+
+	yaml := string(out)
+
+	// MUST contain relative file references
+	mustContain := []string{
+		"certificate-authority: ca.crt",
+		"client-certificate: tls.crt",
+		"client-key: tls.key",
+		"server: https://test-konk.aggregate.svc:6443",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(yaml, s) {
+			t.Errorf("kubeconfig missing required file reference %q\nGot:\n%s", s, yaml)
+		}
+	}
+
+	// MUST NOT contain embedded cert data (the regression we're guarding against)
+	mustNotContain := []string{
+		"certificate-authority-data:",
+		"client-certificate-data:",
+		"client-key-data:",
+	}
+	for _, s := range mustNotContain {
+		if strings.Contains(yaml, s) {
+			t.Errorf("kubeconfig contains embedded cert field %q which breaks dynamic cert rotation\nGot:\n%s", s, yaml)
+		}
+	}
+}
+
+// TestBuildKubeconfig_LoadableAndConsistent verifies the output is a valid
+// kubeconfig that client-go can load, with the expected context wired up.
+func TestBuildKubeconfig_LoadableAndConsistent(t *testing.T) {
+	out, err := buildKubeconfig("my-konk", "my-konk.ns.svc")
+	if err != nil {
+		t.Fatalf("buildKubeconfig returned error: %v", err)
+	}
+
+	cfg, err := clientcmd.Load(out)
+	if err != nil {
+		t.Fatalf("clientcmd.Load failed: %v", err)
+	}
+
+	if cfg.CurrentContext != "my-konk" {
+		t.Errorf("CurrentContext = %q, want %q", cfg.CurrentContext, "my-konk")
+	}
+
+	cluster, ok := cfg.Clusters["my-konk"]
+	if !ok {
+		t.Fatalf("cluster %q missing", "my-konk")
+	}
+	if cluster.Server != "https://my-konk.ns.svc:6443" {
+		t.Errorf("Server = %q", cluster.Server)
+	}
+	if cluster.CertificateAuthority != "ca.crt" {
+		t.Errorf("CertificateAuthority = %q, want %q", cluster.CertificateAuthority, "ca.crt")
+	}
+	if len(cluster.CertificateAuthorityData) != 0 {
+		t.Errorf("CertificateAuthorityData must be empty (regression: rotation breaks if data is embedded)")
+	}
+
+	auth, ok := cfg.AuthInfos["kubernetes-admin"]
+	if !ok {
+		t.Fatalf("AuthInfo %q missing", "kubernetes-admin")
+	}
+	if auth.ClientCertificate != "tls.crt" {
+		t.Errorf("ClientCertificate = %q, want %q", auth.ClientCertificate, "tls.crt")
+	}
+	if auth.ClientKey != "tls.key" {
+		t.Errorf("ClientKey = %q, want %q", auth.ClientKey, "tls.key")
+	}
+	if len(auth.ClientCertificateData) != 0 {
+		t.Errorf("ClientCertificateData must be empty (regression: rotation breaks if data is embedded)")
+	}
+	if len(auth.ClientKeyData) != 0 {
+		t.Errorf("ClientKeyData must be empty (regression: rotation breaks if data is embedded)")
+	}
+}
+
+// TestComputeCertSum_DetectsRotation verifies that the checksum changes when
+// any of the cert files change. This is what triggers the secret update
+// (and, in the rollout-restart PR, dependent deployment annotation patches).
+func TestComputeCertSum_DetectsRotation(t *testing.T) {
+	ca := []byte("ca-data")
+	crt := []byte("crt-data")
+	key := []byte("key-data")
+
+	base := computeCertSum(ca, crt, key)
+
+	cases := []struct {
+		name              string
+		ca, crt, key      []byte
+		shouldDifferFrom  string
+	}{
+		{"ca changed", []byte("ca-data-NEW"), crt, key, base},
+		{"crt changed", ca, []byte("crt-data-NEW"), key, base},
+		{"key changed", ca, crt, []byte("key-data-NEW"), base},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeCertSum(tc.ca, tc.crt, tc.key)
+			if got == tc.shouldDifferFrom {
+				t.Errorf("checksum did not change when %s; rotation would be missed", tc.name)
+			}
+		})
+	}
+
+	// Same inputs must produce the same checksum (stable, no rotation noise)
+	if computeCertSum(ca, crt, key) != base {
+		t.Errorf("computeCertSum is not deterministic")
+	}
+}


### PR DESCRIPTION
Possible fix for the below error in [aggregate namespace](https://grafana-csp.us-dev-2.eng.test.infoblox.com/goto/8hIL2ZJDR?orgId=1)

`E0518 11:10:04.799439       1 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate has expired or is not yet valid: current time 2026-05-18T11:10:04Z is after 2026-05-08T12:06:47Z, verifying certificate SN=196217896459358739084540993147729164715, SKID=, AKID=59:38:2B:4C:26:12:A3:D8:63:F0:14:BC:9E:E4:8B:76:A5:B2:75:8D failed: x509: certificate has expired or is not yet valid: current time 2026-05-18T11:10:04Z is after 2026-05-08T12:06:47Z]"`


The distroless Go rewrite changed the kubeconfig format from file references (certificate-authority: ca.crt, client-certificate: tls.crt) to embedded data (certificate-authority-data: <base64>).

This breaks automatic cert rotation: client-go re-reads cert files from disk on each TLS handshake when file paths are used, but caches embedded data permanently in the TLS transport. With 12h cert duration, consumer pods (e.g. tagging-aggregate-api) get Unauthorized after the in-memory cert expires.

The old shell-based approach (production at 8b64bf7) used:
  kubectl config set-credentials ... --client-certificate tls.crt
  sed -i 's@ /@ @' $KUBECONFIG_PATH

This produced relative file paths that client-go resolves against the Secret mount directory (/etc/kubernetes/), enabling dynamic reload.

This commit restores that behavior in the Go implementation.