### PR TITLE
fix(konk-service): close HTTP/2 transport to prevent memory accumulation

### DIFF
--- a/cmd/konk-service/client.go
+++ b/cmd/konk-service/client.go
@@ -20,47 +20,67 @@ import (
 	"strings"
 )
 
+// closeFunc releases HTTP transport resources (idle connections, HTTP/2 goroutines).
+// Must be called after each reconciliation iteration to prevent memory accumulation
+// from long-lived HTTP/2 transports (known Go net/http2 issue).
+type closeFunc func()
+
 // newInClusterClient creates a kubernetes clientset using in-cluster config.
-func newInClusterClient() (*kubernetes.Clientset, error) {
+// Returns a closeFunc that must be called after use to release HTTP/2 transport resources.
+func newInClusterClient() (*kubernetes.Clientset, closeFunc, error) {
 	rc, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("in-cluster config: %w", err)
+		return nil, nil, fmt.Errorf("in-cluster config: %w", err)
 	}
-	cs, err := kubernetes.NewForConfig(rc)
+	httpClient, err := rest.HTTPClientFor(rc)
 	if err != nil {
-		return nil, fmt.Errorf("creating clientset: %w", err)
+		return nil, nil, fmt.Errorf("creating http client: %w", err)
 	}
-	return cs, nil
-}
-
-// newKubeconfigClient creates kubernetes and dynamic clients from a kubeconfig file.
-func newKubeconfigClient(kubeconfigPath string) (*kubernetes.Clientset, dynamic.Interface, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading kubeconfig %s: %w", kubeconfigPath, err)
-	}
-	cs, err := kubernetes.NewForConfig(cfg)
+	cs, err := kubernetes.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating clientset: %w", err)
 	}
-	dyn, err := dynamic.NewForConfig(cfg)
+	return cs, func() { httpClient.CloseIdleConnections() }, nil
+}
+
+// newKubeconfigClient creates kubernetes and dynamic clients from a kubeconfig file.
+// Returns a closeFunc that must be called after use to release HTTP/2 transport resources.
+func newKubeconfigClient(kubeconfigPath string) (*kubernetes.Clientset, dynamic.Interface, closeFunc, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating dynamic client: %w", err)
+		return nil, nil, nil, fmt.Errorf("loading kubeconfig %s: %w", kubeconfigPath, err)
 	}
-	return cs, dyn, nil
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating http client: %w", err)
+	}
+	cs, err := kubernetes.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating clientset: %w", err)
+	}
+	dyn, err := dynamic.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+	return cs, dyn, func() { httpClient.CloseIdleConnections() }, nil
 }
 
 // newDynamicInClusterClient creates a dynamic client using in-cluster config.
-func newDynamicInClusterClient() (dynamic.Interface, error) {
+// Returns a closeFunc that must be called after use to release HTTP/2 transport resources.
+func newDynamicInClusterClient() (dynamic.Interface, closeFunc, error) {
 	rc, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("in-cluster config: %w", err)
+		return nil, nil, fmt.Errorf("in-cluster config: %w", err)
 	}
-	dyn, err := dynamic.NewForConfig(rc)
+	httpClient, err := rest.HTTPClientFor(rc)
 	if err != nil {
-		return nil, fmt.Errorf("creating dynamic client: %w", err)
+		return nil, nil, fmt.Errorf("creating http client: %w", err)
 	}
-	return dyn, nil
+	dyn, err := dynamic.NewForConfigAndClient(rc, httpClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+	return dyn, func() { httpClient.CloseIdleConnections() }, nil
 }
 
 // applyUnstructured applies a single unstructured object using server-side apply.

--- a/cmd/konk-service/delete_apiservice.go
+++ b/cmd/konk-service/delete_apiservice.go
@@ -31,10 +31,11 @@ func runDeleteAPIService() error {
 	ctx := context.Background()
 
 	// Verify konk is reachable
-	konkClient, dyn, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, dyn, close, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
+	defer close()
 
 	// Quick health check — list nodes (like the original script)
 	_, err = konkClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/cmd/konk-service/delete_apiservice.go
+++ b/cmd/konk-service/delete_apiservice.go
@@ -31,11 +31,11 @@ func runDeleteAPIService() error {
 	ctx := context.Background()
 
 	// Verify konk is reachable
-	konkClient, dyn, close, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, dyn, cleanup, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
-	defer close()
+	defer cleanup()
 
 	// Quick health check — list nodes (like the original script)
 	_, err = konkClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/cmd/konk-service/reconcile_apiservice.go
+++ b/cmd/konk-service/reconcile_apiservice.go
@@ -75,11 +75,11 @@ func reconcileAPIServiceOnce(ctx context.Context, kubeconfigPath, certDir, servi
 
 	// Create a fresh client each iteration to prevent HTTP/2 transport
 	// memory accumulation on long-lived connections (known Go net/http2 issue).
-	_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
+	_, dyn, cleanup, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
-	defer close()
+	defer cleanup()
 
 	objects, err := parseMultiDocYAML(rendered)
 	if err != nil {

--- a/cmd/konk-service/reconcile_apiservice.go
+++ b/cmd/konk-service/reconcile_apiservice.go
@@ -73,11 +73,13 @@ func reconcileAPIServiceOnce(ctx context.Context, kubeconfigPath, certDir, servi
 		rendered = strings.ReplaceAll(rendered, old, certB64)
 	}
 
-	// Parse and apply
-	_, dyn, err := newKubeconfigClient(kubeconfigPath)
+	// Create a fresh client each iteration to prevent HTTP/2 transport
+	// memory accumulation on long-lived connections (known Go net/http2 issue).
+	_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
+	defer close()
 
 	objects, err := parseMultiDocYAML(rendered)
 	if err != nil {

--- a/cmd/konk-service/reconcile_kubeconfig.go
+++ b/cmd/konk-service/reconcile_kubeconfig.go
@@ -43,18 +43,22 @@ func runReconcileKubeconfig() error {
 
 	labels := parseLabels(labelsStr)
 
-	infraClient, err := newInClusterClient()
-	if err != nil {
-		return fmt.Errorf("creating infra client: %w", err)
-	}
-
 	ctx := context.Background()
 	secretName := fullname + "-kubeconfig"
 	var lastCertSum string
 
 	for {
 		log.Println("Reconciling kubeconfig...")
-		reconcileOnce(ctx, infraClient, kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName, labels, &lastCertSum)
+
+		// Create a fresh client each iteration to prevent HTTP/2 transport
+		// memory accumulation on long-lived connections (known Go net/http2 issue).
+		infraClient, close, err := newInClusterClient()
+		if err != nil {
+			log.Printf("Error creating infra client: %v", err)
+		} else {
+			reconcileOnce(ctx, infraClient, kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName, labels, &lastCertSum)
+			close()
+		}
 
 		// 3 minute loop with 30s jitter (matching original shell)
 		jitter := time.Duration(rand.Intn(30)) * time.Second

--- a/cmd/konk-service/reconcile_kubeconfig.go
+++ b/cmd/konk-service/reconcile_kubeconfig.go
@@ -50,15 +50,17 @@ func runReconcileKubeconfig() error {
 	for {
 		log.Println("Reconciling kubeconfig...")
 
-		// Create a fresh client each iteration to prevent HTTP/2 transport
-		// memory accumulation on long-lived connections (known Go net/http2 issue).
-		infraClient, close, err := newInClusterClient()
-		if err != nil {
-			log.Printf("Error creating infra client: %v", err)
-		} else {
+		// Wrap in an anonymous function so defer cleanup() fires at end of
+		// each iteration, releasing the HTTP/2 transport even if reconcileOnce panics.
+		func() {
+			infraClient, cleanup, err := newInClusterClient()
+			if err != nil {
+				log.Printf("Error creating infra client: %v", err)
+				return
+			}
+			defer cleanup()
 			reconcileOnce(ctx, infraClient, kubeconfigPath, certDir, konkName, konkFQDN, namespace, fullname, secretName, labels, &lastCertSum)
-			close()
-		}
+		}()
 
 		// 3 minute loop with 30s jitter (matching original shell)
 		jitter := time.Duration(rand.Intn(30)) * time.Second

--- a/cmd/konk-service/test_apiservice.go
+++ b/cmd/konk-service/test_apiservice.go
@@ -41,11 +41,12 @@ func runTestAPIService() error {
 func testAPIServiceOnce(kubeconfigPath, apiServiceName, group string) int {
 	ctx := context.Background()
 
-	konkClient, _, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, _, close1, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		log.Printf("Error creating konk client: %v", err)
 		return 1
 	}
+	defer close1()
 
 	// Check APIService exists
 	apiregGVR := schema.GroupVersionResource{
@@ -53,11 +54,12 @@ func testAPIServiceOnce(kubeconfigPath, apiServiceName, group string) int {
 		Version:  "v1",
 		Resource: "apiservices",
 	}
-	_, dynClient, err := newKubeconfigClient(kubeconfigPath)
+	_, dynClient, close2, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		log.Printf("Error creating dynamic client: %v", err)
 		return 1
 	}
+	defer close2()
 	_, err = dynClient.Resource(apiregGVR).Get(ctx, apiServiceName, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("APIService %s not found: %v", apiServiceName, err)

--- a/cmd/konk-service/test_apiservice.go
+++ b/cmd/konk-service/test_apiservice.go
@@ -41,12 +41,12 @@ func runTestAPIService() error {
 func testAPIServiceOnce(kubeconfigPath, apiServiceName, group string) int {
 	ctx := context.Background()
 
-	konkClient, _, close1, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, dynClient, cleanup, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		log.Printf("Error creating konk client: %v", err)
 		return 1
 	}
-	defer close1()
+	defer cleanup()
 
 	// Check APIService exists
 	apiregGVR := schema.GroupVersionResource{
@@ -54,12 +54,6 @@ func testAPIServiceOnce(kubeconfigPath, apiServiceName, group string) int {
 		Version:  "v1",
 		Resource: "apiservices",
 	}
-	_, dynClient, close2, err := newKubeconfigClient(kubeconfigPath)
-	if err != nil {
-		log.Printf("Error creating dynamic client: %v", err)
-		return 1
-	}
-	defer close2()
 	_, err = dynClient.Resource(apiregGVR).Get(ctx, apiServiceName, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("APIService %s not found: %v", apiServiceName, err)

--- a/cmd/konk-service/test_connection.go
+++ b/cmd/konk-service/test_connection.go
@@ -60,7 +60,7 @@ func runTestConnection() error {
 
 func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 	for {
-		client, _, close, err := newKubeconfigClient(kubeconfigPath)
+		client, _, cleanup, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			// Use Discovery to check that the API server is reachable.
 			// A konk API server is a bare kube-apiserver without a
@@ -68,7 +68,7 @@ func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 			// default namespace does not exist.  Calling ServerVersion()
 			// hits the /version endpoint which is always available.
 			_, err = client.Discovery().ServerVersion()
-			close()
+			cleanup()
 			if err == nil {
 				return nil
 			}
@@ -84,10 +84,10 @@ func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 
 func waitForAPIServices(ctx context.Context, kubeconfigPath string) error {
 	for {
-		client, _, close, err := newKubeconfigClient(kubeconfigPath)
+		client, _, cleanup, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = client.Discovery().ServerGroups()
-			close()
+			cleanup()
 			if err == nil {
 				return nil
 			}

--- a/cmd/konk-service/test_connection.go
+++ b/cmd/konk-service/test_connection.go
@@ -60,7 +60,7 @@ func runTestConnection() error {
 
 func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 	for {
-		client, _, err := newKubeconfigClient(kubeconfigPath)
+		client, _, close, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			// Use Discovery to check that the API server is reachable.
 			// A konk API server is a bare kube-apiserver without a
@@ -68,6 +68,7 @@ func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 			// default namespace does not exist.  Calling ServerVersion()
 			// hits the /version endpoint which is always available.
 			_, err = client.Discovery().ServerVersion()
+			close()
 			if err == nil {
 				return nil
 			}
@@ -83,9 +84,10 @@ func waitForClusterInfo(ctx context.Context, kubeconfigPath string) error {
 
 func waitForAPIServices(ctx context.Context, kubeconfigPath string) error {
 	for {
-		client, _, err := newKubeconfigClient(kubeconfigPath)
+		client, _, close, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = client.Discovery().ServerGroups()
+			close()
 			if err == nil {
 				return nil
 			}

--- a/cmd/konk-service/test_setup.go
+++ b/cmd/konk-service/test_setup.go
@@ -34,11 +34,11 @@ func runTestSetup() error {
 
 	ctx := context.Background()
 
-	konkClient, dynClient, close, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, dynClient, cleanup, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
-	defer close()
+	defer cleanup()
 
 	// Check RBAC: can-i create apiservice
 	log.Println("Checking RBAC: can create apiservice...")

--- a/cmd/konk-service/test_setup.go
+++ b/cmd/konk-service/test_setup.go
@@ -34,10 +34,11 @@ func runTestSetup() error {
 
 	ctx := context.Background()
 
-	konkClient, dynClient, err := newKubeconfigClient(kubeconfigPath)
+	konkClient, dynClient, close, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("creating konk client: %w", err)
 	}
+	defer close()
 
 	// Check RBAC: can-i create apiservice
 	log.Println("Checking RBAC: can create apiservice...")

--- a/cmd/konk-service/wait_and_example.go
+++ b/cmd/konk-service/wait_and_example.go
@@ -36,9 +36,10 @@ func runWaitForResource() error {
 
 	log.Printf("Waiting for resource %s.%s/%s to be available...", resource, group, version)
 	for {
-		_, dyn, err := newKubeconfigClient(kubeconfigPath)
+		_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = dyn.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+			close()
 			if err == nil {
 				log.Printf("Resource %s is available", resource)
 				return nil
@@ -86,9 +87,10 @@ func runExampleTest() error {
 	}
 	log.Printf("Waiting for resource %s to be available...", resource)
 	for {
-		_, dyn, err := newKubeconfigClient(kubeconfigPath)
+		_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1})
+			close()
 			if err == nil {
 				break
 			}
@@ -98,10 +100,11 @@ func runExampleTest() error {
 	}
 
 	// Create sample resource
-	_, dyn, err := newKubeconfigClient(kubeconfigPath)
+	_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return err
 	}
+	defer close()
 
 	sampleObj := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/cmd/konk-service/wait_and_example.go
+++ b/cmd/konk-service/wait_and_example.go
@@ -36,10 +36,10 @@ func runWaitForResource() error {
 
 	log.Printf("Waiting for resource %s.%s/%s to be available...", resource, group, version)
 	for {
-		_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
+		_, dyn, cleanup, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = dyn.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
-			close()
+			cleanup()
 			if err == nil {
 				log.Printf("Resource %s is available", resource)
 				return nil
@@ -87,10 +87,10 @@ func runExampleTest() error {
 	}
 	log.Printf("Waiting for resource %s to be available...", resource)
 	for {
-		_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
+		_, dyn, cleanup, err := newKubeconfigClient(kubeconfigPath)
 		if err == nil {
 			_, err = dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1})
-			close()
+			cleanup()
 			if err == nil {
 				break
 			}
@@ -100,11 +100,11 @@ func runExampleTest() error {
 	}
 
 	// Create sample resource
-	_, dyn, close, err := newKubeconfigClient(kubeconfigPath)
+	_, dyn, cleanup, err := newKubeconfigClient(kubeconfigPath)
 	if err != nil {
 		return err
 	}
-	defer close()
+	defer cleanup()
 
 	sampleObj := &unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
## Problem

The apiservice container in konk-service pods exhibits steady memory growth (~6.5 MiB/month) due to Go net/http2 transport retaining background goroutines on long-lived connections. Observed on us-dev-5 (tagging-v2 namespace, container=apiservice).

Additionally, reconcile_kubeconfig.go created a single Kubernetes client once outside the loop, causing indefinite HTTP/2 buffer accumulation.

**Jira:** [PTOCP-5175](https://infoblox.atlassian.net/browse/PTOCP-5175)

<img width="1715" height="883" alt="image" src="https://github.com/user-attachments/assets/9235b046-f038-426f-a967-530e0e84cf70" />


## Root Cause

Go HTTP/2 transport maintains background goroutines (ping, keepalive) that hold references to the transport, preventing GC even after client is unreferenced.

## Fix

- Client factories return a closeFunc calling httpClient.CloseIdleConnections()
- Use rest.HTTPClientFor() + NewForConfigAndClient() for explicit HTTP client control
- reconcile_kubeconfig: move client creation inside loop
- reconcile_apiservice: add defer close()
- All callers updated

## Testing

- go build ./... pass
- go test ./... pass
- Memory growth should flatten after ~1 week