### PR TITLE
ci: retry GHCR push on transient unknown-blob errors

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -36,29 +36,28 @@ jobs:
     - name: Push Images to GHCR
       env:
         BUILDKIT_PROGRESS: plain
-      # Retry up to 3 times to handle transient GHCR "unknown blob" errors.
+      # Retry each image individually so a transient GHCR "unknown blob" failure
+      # on one image does not force a re-push of images that already succeeded.
       run: |
-        for attempt in 1 2 3; do
-          make docker-push && \
-          make docker-push-kubernetes && \
-          make docker-push-provision && \
-          make docker-push-konk-service && break
-          echo "Push attempt $attempt failed, retrying in 15s..."
-          sleep 15
+        for target in docker-push docker-push-kubernetes docker-push-provision docker-push-konk-service; do
+          for attempt in 1 2 3; do
+            make $target && break
+            echo "$target attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
         done
     - name: Tag :latest and push to GHCR
       env:
         BUILDKIT_PROGRESS: plain
-      # Retry up to 3 times to handle transient GHCR "unknown blob" errors.
+      # Retry each image individually so a failure on one image does not
+      # force a re-push of images that already succeeded.
       run: |
         GIT_VERSION=$(git describe --always --long --tags)
-        for attempt in 1 2 3; do
-          ok=true
-          for img in konk konk-app konk-provision konk-service; do
-            docker tag ghcr.io/infobloxopen/${img}:${GIT_VERSION} ghcr.io/infobloxopen/${img}:latest
-            docker push ghcr.io/infobloxopen/${img}:latest || ok=false
+        for img in konk konk-app konk-provision konk-service; do
+          docker tag ghcr.io/infobloxopen/${img}:${GIT_VERSION} ghcr.io/infobloxopen/${img}:latest
+          for attempt in 1 2 3; do
+            docker push ghcr.io/infobloxopen/${img}:latest && break
+            echo "${img}:latest attempt $attempt failed, retrying in 15s..."
+            sleep 15
           done
-          $ok && break
-          echo "Tag+push attempt $attempt failed, retrying in 15s..."
-          sleep 15
         done

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -36,17 +36,29 @@ jobs:
     - name: Push Images to GHCR
       env:
         BUILDKIT_PROGRESS: plain
+      # Retry up to 3 times to handle transient GHCR "unknown blob" errors.
       run: |
-        make docker-push
-        make docker-push-kubernetes
-        make docker-push-provision
-        make docker-push-konk-service
+        for attempt in 1 2 3; do
+          make docker-push && \
+          make docker-push-kubernetes && \
+          make docker-push-provision && \
+          make docker-push-konk-service && break
+          echo "Push attempt $attempt failed, retrying in 15s..."
+          sleep 15
+        done
     - name: Tag :latest and push to GHCR
       env:
         BUILDKIT_PROGRESS: plain
+      # Retry up to 3 times to handle transient GHCR "unknown blob" errors.
       run: |
         GIT_VERSION=$(git describe --always --long --tags)
-        for img in konk konk-app konk-provision konk-service; do
-          docker tag ghcr.io/infobloxopen/${img}:${GIT_VERSION} ghcr.io/infobloxopen/${img}:latest
-          docker push ghcr.io/infobloxopen/${img}:latest
+        for attempt in 1 2 3; do
+          ok=true
+          for img in konk konk-app konk-provision konk-service; do
+            docker tag ghcr.io/infobloxopen/${img}:${GIT_VERSION} ghcr.io/infobloxopen/${img}:latest
+            docker push ghcr.io/infobloxopen/${img}:latest || ok=false
+          done
+          $ok && break
+          echo "Tag+push attempt $attempt failed, retrying in 15s..."
+          sleep 15
         done


### PR DESCRIPTION
## Problem

The `push-images` workflow failed after merging PR #625 with:
```
unknown blob
make: *** [Makefile:191: docker-push-konk-service] Error 1
```

This is a known transient issue with GitHub Container Registry (GHCR) — the backend storage occasionally loses track of a blob manifest between the layer push and the final registry commit. It is unrelated to the code changes.

## Fix

Add a 3-attempt retry loop with 15s backoff to both push steps:
- **Push Images to GHCR** — wraps all four `make docker-push-*` calls
- **Tag :latest and push to GHCR** — retries per-image on failure

## Reference

- Failed run: https://github.com/infobloxopen/konk/actions/runs/27349051693/job/80805499805