### PR TITLE
fix(ci): add --provenance=false to all docker builds to fix GHCR push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ undeploy: kustomize
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 .image-${GIT_VERSION}:
-	DOCKER_BUILDKIT=1 docker build . -t ${IMG}
+	DOCKER_BUILDKIT=1 docker build --provenance=false . -t ${IMG}
 	touch $@
 
 # Build the docker image
@@ -148,7 +148,7 @@ docker-push:
 
 # Build patched kubernetes (kubeadm + kube-apiserver) from source with upgraded deps
 .kubernetes-image-${GIT_VERSION}:
-	DOCKER_BUILDKIT=1 docker build \
+	DOCKER_BUILDKIT=1 docker build --provenance=false \
 		--build-arg K8S_VERSION=$(K8S_RELEASE) \
 		-t ${KUBERNETES_IMG} \
 		build/kubernetes/
@@ -167,7 +167,7 @@ docker-push-kubernetes:
 
 # Build the provision docker image (depends on kubernetes build)
 .provision-image-${GIT_VERSION}: .kubernetes-image-${GIT_VERSION}
-	DOCKER_BUILDKIT=1 docker build \
+	DOCKER_BUILDKIT=1 docker build --provenance=false \
 		--build-arg KUBERNETES_IMG=${KUBERNETES_IMG} \
 		-f Dockerfile.provision . -t ${PROVISION_IMG}
 	touch $@
@@ -180,7 +180,7 @@ docker-push-provision:
 
 # Build the konk-service docker image (Go binary replacing shell-based konk-tools for konk-service chart)
 .konk-service-image-${GIT_VERSION}:
-	DOCKER_BUILDKIT=1 docker build \
+	DOCKER_BUILDKIT=1 docker build --provenance=false \
 		-f Dockerfile.konk-service . -t ${KONK_SERVICE_IMG}
 	touch $@
 


### PR DESCRIPTION
## Problem

Run #35 failed 3 consecutive times (all previous runs since PR #584 succeeded):
```
unknown blob
make: *** [Makefile:191: docker-push-konk-service] Error 1
```

## Root Cause

`DOCKER_BUILDKIT=1 docker build` on Docker 25+ generates an OCI image index manifest that includes provenance attestation blobs. GHCR fails to verify these referenced blobs on push, producing `unknown blob` errors.

The most likely trigger is a **Docker version bump on the `ubuntu-latest` runner** between the last successful run (#34, May 20) and run #35 (Jun 11), which changed BuildKit's default manifest generation behaviour.

Reference: https://github.com/docker/buildx/issues/1509

## Fix

Add `--provenance=false` to all four `docker build` targets in the Makefile. This suppresses OCI attestation manifests and produces plain Docker v2 manifests that GHCR handles reliably. This is the documented fix for this class of GHCR push failure.

## Related

- PR #626 — adds per-image retry loop as a secondary safety net for genuine transient GHCR errors