### PR TITLE
fix(konk-service): remove obsolete 'kubectl-' prefix from deployment names

### DIFF
--- a/helm-charts/konk-service/templates/apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "konk-service.fullname" . | trunc 43 | trimSuffix "-" }}-kubectl-apiservice
+  name: {{ include "konk-service.fullname" . | trunc 51 | trimSuffix "-" }}-apiservice
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "konk-service.fullname" . | trunc 39 | trimSuffix "-" }}-kubectl-apiservice-test
+  name: {{ include "konk-service.fullname" . | trunc 46 | trimSuffix "-" }}-apiservice-test
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}


### PR DESCRIPTION
## Summary

Remove the `kubectl-` prefix from the konk-service apiservice and apiservice-test deployment name suffixes. This frees up 8 characters for the release name (KonkService CR name) and eliminates a historical naming artifact.

## Motivation

### 1. `kubectl` is no longer used — historical artifact

These deployments were originally named `kubectl-apiservice` because they shelled out to the `kubectl` binary to apply APIService manifests. The implementation was later rewritten to use the native `konk-service` Go binary with subcommands (`reconcile-apiservice`, `test-apiservice`). The `kubectl-` prefix became a misleading leftover:

```yaml
# The actual command — no kubectl involved:
command: ["/usr/local/bin/konk-service", "reconcile-apiservice"]
```

### 2. Name truncation causes collision risk and obscures pod identity

Kubernetes limits resource names to 63 characters (DNS label). The konk-service chart builds deployment names as:

```
<fullname> + <suffix>
```

Where `fullname = <KonkService-CR-name>-konk-service`. With long CR names, the fullname gets truncated to make room for the suffix. The old suffixes were:

| Suffix | Length | Available for fullname (63 - suffix) |
|--------|--------|--------------------------------------|
| `-kubectl-apiservice` | 20 | 43 |
| `-kubectl-apiservice-test` | 25 | 39 → only ~26 chars for the CR name |

**Collision example:** If two KonkService CRs in the same namespace had names differing only after the 26th character (after appending `-konk-service`), the test deployments would collide:

```
# CR: "dns-config-importexport-apiservice"     (34 chars)
# CR: "dns-config-importexport-apiservice-v2"  (37 chars)
#
# Old fullnames (with -konk-service appended):
#   dns-config-importexport-apiservice-konk-service     (47 chars)
#   dns-config-importexport-apiservice-v2-konk-service  (50 chars)
#
# After trunc 39:
#   dns-config-importexport-apiservice-konk  (unique ✓ — but barely)
#   dns-config-importexport-apiservice-v2-k  (unique ✓ — one char difference!)
```

With the new shorter suffixes:

| Suffix | Length | Available for fullname (63 - suffix) |
|--------|--------|--------------------------------------|
| `-apiservice` | 12 | **51** |
| `-apiservice-test` | 17 | **46** → ~33 chars for the CR name |

This gives 7–8 more characters of uniqueness for the release name.

### 3. Pod names are unreadable when deployment name hits 63 chars

When the deployment name is exactly 63 characters, the Kubernetes-generated Pod name (deployment + RS hash + pod suffix) gets long and the meaningful `-test` suffix ends up buried or truncated in `kubectl get pods` output:

**Before (current, hard to identify):**
```
keys-importexport-apiservice-konk-servi-kubectl-apiservice-test-5946d77bb4-sjc2b
```

**After (clear component identification):**
```
keys-importexport-apiservice-konk-service-apiservice-test-5946d77bb4-sjc2b
```

## Changes

| File | Before | After |
|------|--------|-------|
| `apiservice-deployment.yaml` | `fullname \| trunc 43 \| ... -kubectl-apiservice` | `fullname \| trunc 51 \| ... -apiservice` |
| `apiservice-test-deployment.yaml` | `fullname \| trunc 39 \| ... -kubectl-apiservice-test` | `fullname \| trunc 46 \| ... -apiservice-test` |

## Breaking Change — Orphan Cleanup Required

Since Helm tracks resources by name, renaming a deployment causes Helm to create the **new** deployment but leaves the **old** one orphaned. After upgrading, run this cleanup on each cluster:

```bash
# Find orphaned old-name deployments (they will have "kubectl-apiservice" in the name)
kubectl get deploy -A | grep "konk-service-kubectl-apiservice"

# Delete them (they are no longer managed by Helm)
kubectl delete deploy -n <namespace> <old-deployment-name>
```

**Note:** On us-dev-5 we already observed this orphan problem from the previous `trunc 39` change — old deployments with 0/1 available replicas running stale test pods indefinitely.

## No Collision Risk

The remaining suffixes are all unique:
- `-kubeconfig` (kubeconfig deployment)
- `-apiservice` (apiservice reconciler — this PR)
- `-apiservice-test` (apiservice health checker — this PR)
- `-delete-apiservice` (pre-delete hook Job)
