### PR TITLE
feat(etcd): parameterize volumeClaimTemplate name for migration

### DIFF
--- a/helm-charts/etcd/templates/statefulset.yaml
+++ b/helm-charts/etcd/templates/statefulset.yaml
@@ -234,7 +234,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
+            - name: {{ .Values.persistence.claimName | default "data" }}
               mountPath: {{ .Values.etcd.dataDir }}
             {{- if and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS) }}
             - name: etcd-client-certs
@@ -262,7 +262,7 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: data
+        name: {{ .Values.persistence.claimName | default "data" }}
         {{- with .Values.persistence.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}
@@ -277,6 +277,6 @@ spec:
             storage: {{ .Values.persistence.size | quote }}
         {{- include "etcd.storageClass" . | nindent 8 }}
   {{- else }}
-        - name: data
+        - name: {{ .Values.persistence.claimName | default "data" }}
           emptyDir: {}
   {{- end }}

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -66,6 +66,8 @@ service:
 ## @section Persistence parameters
 persistence:
   enabled: true
+  ## @param persistence.claimName Name for the volumeClaimTemplate. Change to provision fresh PVCs on upgrade (e.g. "data-v2").
+  claimName: data
   storageClass: ""
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary

Adds a configurable `persistence.claimName` value (default: `data`) to the etcd Helm chart, allowing fresh PVCs to be provisioned on upgrade by changing the claim name (e.g. `data-v2`).

## Problem

When upgrading from Bitnami etcd (3.5.x) to upstream etcd (3.6.x), the new etcd finds incompatible Bitnami data in reused PVCs, logs `server has already been initialized`, and crash-loops.

## Solution

Parameterize the `volumeClaimTemplates[].metadata.name` so operators can set a new claim name per-cluster during migration:

```yaml
persistence:
  claimName: data-v2
etcd:
  initialClusterState: "new"
```

This provisions fresh empty PVCs (`data-v2-bulk-konk-etcd-{0,1,2}`) while leaving old `data-*` PVCs untouched as on-cluster backup. No PVC deletion required.

## Changes

- `helm-charts/etcd/values.yaml` — added `persistence.claimName: data`
- `helm-charts/etcd/templates/statefulset.yaml` — replaced hardcoded `name: data` with `{{ .Values.persistence.claimName | default "data" }}` in volumeClaimTemplate, volumeMount, and emptyDir fallback

## Backward Compatibility

Default value is `data`, so existing deployments are unaffected.