### PR TITLE
feat(etcd): declarative StatefulSet recreate hook for claimName/PVC migration

### DIFF
--- a/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
+++ b/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
@@ -87,8 +87,15 @@ spec:
   backoffLimit: 3
   template:
     metadata:
+      # Deliberately NOT etcd.selectorLabels: the etcd client/headless Services
+      # select on {name: etcd, instance: <release>}. Reusing those labels would
+      # add this kubectl pod to the etcd Service Endpoints (it has no readiness
+      # probe, so it is Ready immediately), causing the apiserver to route etcd
+      # traffic to a pod that does not serve etcd. Use a distinct name instead.
       labels:
-        {{- include "etcd.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "etcd.name" . }}-recreate-hook
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: recreate-hook
     spec:
       restartPolicy: Never
       serviceAccountName: {{ $name }}-recreate-hook

--- a/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
+++ b/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
@@ -1,0 +1,129 @@
+{{- /*
+StatefulSet volumeClaimTemplate names are immutable. When persistence.claimName
+changes (e.g. "data" -> "data-v2"), Kubernetes rejects the in-place StatefulSet
+update and the Helm operator loops in a failed-upgrade / rollback cycle. This
+pre-upgrade hook deletes the existing StatefulSet so Helm recreates it with the
+new claimName (a CREATE, which has no immutable-field restriction).
+
+It is gated two ways so it is safe to leave enabled:
+  1. recreateStatefulSet.enabled must be true, AND
+  2. the LIVE StatefulSet's volumeClaimTemplate name must differ from the desired
+     persistence.claimName (looked up at render time).
+Once migrated, the live claimName matches the target and the hook renders nothing.
+
+Existing PVCs are retained (StatefulSet PVCs are not garbage-collected on delete),
+so the old volumes remain available as a backup.
+*/ -}}
+{{- if and .Values.recreateStatefulSet.enabled .Values.persistence.enabled }}
+{{- $name := include "etcd.fullname" . }}
+{{- $target := .Values.persistence.claimName | default "data" }}
+{{- $live := lookup "apps/v1" "StatefulSet" .Release.Namespace $name }}
+{{- $currentClaim := "" }}
+{{- if and $live $live.spec.volumeClaimTemplates }}
+{{- $currentClaim = (index $live.spec.volumeClaimTemplates 0).metadata.name }}
+{{- end }}
+{{- if and $currentClaim (ne $currentClaim $target) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}-recreate-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-recreate-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    resourceNames: ["{{ $name }}"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-recreate-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-4"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}-recreate-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}-recreate-hook
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name | trunc 50 | trimSuffix "-" }}-recreate-sts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "etcd.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $name }}-recreate-hook
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+        - name: recreate-sts
+          image: "{{ .Values.recreateStatefulSet.image.repository }}:{{ .Values.recreateStatefulSet.image.tag }}"
+          imagePullPolicy: {{ .Values.recreateStatefulSet.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - kubectl
+            - delete
+            - statefulset
+            - {{ $name }}
+            - --namespace
+            - {{ .Release.Namespace }}
+            - --ignore-not-found
+            - --wait=true
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            {{- toYaml .Values.recreateStatefulSet.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -74,6 +74,33 @@ persistence:
   size: 8Gi
   annotations: {}
 
+## @section StatefulSet recreate hook (claimName / PVC migration)
+## A StatefulSet's volumeClaimTemplate name is immutable. When persistence.claimName
+## changes (e.g. "data" -> "data-v2"), an in-place upgrade is rejected by the API
+## server ("updates to statefulset spec for fields other than ... are forbidden"),
+## and the Helm operator loops in a failed-upgrade / rollback cycle. This optional
+## pre-upgrade hook deletes the existing StatefulSet so Helm recreates it with the
+## new claimName. It only runs when the LIVE volumeClaimTemplate name differs from
+## persistence.claimName, so it is idempotent and a no-op once migrated. Existing
+## PVCs are retained (StatefulSet PVCs are not garbage-collected on delete) as a backup.
+recreateStatefulSet:
+  ## @param recreateStatefulSet.enabled Enable the pre-upgrade hook that recreates the StatefulSet when persistence.claimName changes
+  enabled: false
+  image:
+    ## @param recreateStatefulSet.image.repository kubectl image used by the recreate hook Job (override for air-gapped registries)
+    repository: registry.k8s.io/kubectl
+    ## @param recreateStatefulSet.image.tag kubectl image tag
+    tag: "v1.31.4"
+    ## @param recreateStatefulSet.image.pullPolicy kubectl image pull policy
+    pullPolicy: IfNotPresent
+  ## @param recreateStatefulSet.resources Resource requests/limits for the recreate hook Job
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
 ## @section Pod parameters
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
## Problem

Approach B (etcd PVC migration via parameterized `persistence.claimName`, e.g. `data` → `data-v2`) cannot be applied by a plain version-bump / `helm upgrade` on a cluster that already has an etcd StatefulSet.

A StatefulSet's `volumeClaimTemplates[].metadata.name` is **immutable**. When `claimName` changes, the operator's in-place `helm upgrade` is rejected:

```
StatefulSet.apps "bulk-konk-etcd" is invalid: spec: Forbidden:
updates to statefulset spec for fields other than 'replicas','ordinals','template',
'updateStrategy','persistentVolumeClaimRetentionPolicy','minReadySeconds' are forbidden
```

The Helm operator then loops in a failed-upgrade → rollback cycle every reconcile (observed on us-dev-5: revision raced past 60 in a day). Pods stay `Running` on the old `data` spec, so it *looks* healthy but the migration never converges. The only workaround today is a manual `helm uninstall bulk-konk-etcd`.

## Change

Adds an **optional, value-gated `pre-upgrade` hook** to the etcd chart that deletes the existing StatefulSet so Helm recreates it fresh with the new `claimName` (a CREATE has no immutable-field restriction).

- New value `recreateStatefulSet.enabled` (default `false`) — opt-in.
- The hook only materializes when the **live** StatefulSet's `volumeClaimTemplate` name differs from the target `persistence.claimName` (via `lookup`). It is therefore **idempotent** and a no-op once migrated — safe to leave enabled.
- Ships its own scoped RBAC (ServiceAccount + Role limited to `get`/`delete` on the single `<release>` StatefulSet + RoleBinding), ordered ahead of the Job via hook weights, cleaned up via `before-hook-creation,hook-succeeded`.
- Existing PVCs are **retained** (StatefulSet PVCs are not garbage-collected on delete) as a backup.
- kubectl image is overridable (`recreateStatefulSet.image.*`) for air-gapped registries.

## Migration flow (declarative, no manual command)

1. Set the migration values **plus** `recreateStatefulSet.enabled: true` and `persistence.claimName: data-v2`.
2. Operator's `helm upgrade` runs the pre-upgrade hook → old STS deleted → Helm recreates it with `data-v2` → fresh PVCs → bootstrap `new` → KonkServices repopulate.
3. (Optional) set `recreateStatefulSet.enabled: false` again after soak.

## Validation

- `helm lint helm-charts/etcd` → 0 failures.
- `helm template` parses with the hook enabled.
- Force-rendered the hook (bypassing `lookup`) — ServiceAccount/Role/RoleBinding/Job render as valid, correctly-scoped YAML.

## Notes

- Targets `release/upgrade-etcd` so the resulting image carries both the `claimName` param (#631) and this recreate hook.
- `lookup` returns empty during `helm template`/`--dry-run`, so the hook only renders during real operator-driven upgrades — expected.