### PR TITLE
fix: add meta.helm.sh ownership annotations to chart templates

### DIFF
--- a/helm-charts/etcd/templates/_helpers.tpl
+++ b/helm-charts/etcd/templates/_helpers.tpl
@@ -166,3 +166,11 @@ imagePullSecrets:
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Helm ownership annotations — ensures resources can be adopted after release secret loss.
+*/}}
+{{- define "etcd.helmAnnotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
+++ b/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
@@ -31,6 +31,7 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -43,6 +44,7 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -60,6 +62,7 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-4"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -80,6 +83,7 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/helm-charts/etcd/templates/statefulset.yaml
+++ b/helm-charts/etcd/templates/statefulset.yaml
@@ -3,6 +3,8 @@ kind: StatefulSet
 metadata:
   name: {{ include "etcd.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/etcd/templates/svc-headless.yaml
+++ b/helm-charts/etcd/templates/svc-headless.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: {{ include "etcd.headlessServiceName" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/etcd/templates/svc.yaml
+++ b/helm-charts/etcd/templates/svc.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
   annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
+    {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-charts/konk-service/templates/_helpers.tpl
+++ b/helm-charts/konk-service/templates/_helpers.tpl
@@ -85,6 +85,16 @@ dummy
 {{- end -}}
 
 {{/*
+Helm ownership annotations — ensures resources can be adopted after release secret loss.
+Without these, a fresh helm install will fail with "cannot be imported" if the
+operator loses its release state (e.g. after an upgrade or ownerRef GC).
+*/}}
+{{- define "konk-service.helmAnnotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+{{- end -}}
+
+{{/*
 Templates konk name
 */}}
 {{- define "konk-service.konkname" -}}

--- a/helm-charts/konk-service/templates/apiservice-configmap.yaml
+++ b/helm-charts/konk-service/templates/apiservice-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "konk-service.fullname" . }}-mounts
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 data:

--- a/helm-charts/konk-service/templates/apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubectl-apiservice
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubectl-apiservice-test
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/ca.yaml
+++ b/helm-charts/konk-service/templates/ca.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk-service.fullname" . }}
+  secretTemplate:
+    annotations:
+      {{- include "konk-service.helmAnnotations" . | nindent 6 }}
   duration: 17520h #2y
   issuerRef:
     name: {{ include "konk-service.fullname" . }}-self-signed

--- a/helm-charts/konk-service/templates/ca.yaml
+++ b/helm-charts/konk-service/templates/ca.yaml
@@ -4,6 +4,8 @@ kind: Issuer
 metadata:
   name: {{ include "konk-service.fullname" . }}-self-signed
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:
@@ -14,6 +16,8 @@ kind: Certificate
 metadata:
   name: {{ include "konk-service.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:
@@ -30,6 +34,8 @@ kind: Issuer
 metadata:
   name: {{ include "konk-service.fullname" . }}-ca
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/certificate.yaml
+++ b/helm-charts/konk-service/templates/certificate.yaml
@@ -3,6 +3,8 @@ apiVersion: {{ include "konk-service.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
   name: {{ include "konk-service.fullname" . }}-server
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/certificate.yaml
+++ b/helm-charts/konk-service/templates/certificate.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk-service.fullname" . }}-server
+  secretTemplate:
+    annotations:
+      {{- include "konk-service.helmAnnotations" . | nindent 6 }}
   duration: 8760h # 1y
   issuerRef:
     name: {{ include "konk-service.fullname" . }}-ca

--- a/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/delete-apiservice-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
   annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
     helm.sh/hook: pre-delete
 spec:
   template:

--- a/helm-charts/konk-service/templates/ingress.yaml
+++ b/helm-charts/konk-service/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
   annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   {{- with .Values.authURL }}
     nginx.ingress.kubernetes.io/auth-url: {{ . }}
     nginx.ingress.kubernetes.io/auth-response-headers: Authorization,Request-Id

--- a/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk-service.fullname" . }}-kubeconfig-cert
+  secretTemplate:
+    annotations:
+      {{- include "konk-service.helmAnnotations" . | nindent 6 }}
   subject:
     organizations:
     - system:masters

--- a/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-certificate.yaml
@@ -3,6 +3,8 @@ kind: Certificate
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubeconfig
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -62,6 +62,9 @@ spec:
                   --from-file=/tmp/certs/tls.crt \
                   --from-file=/tmp/certs/tls.key
                 kubectl -n $NAMESPACE label secret {{ include "konk-service.fullname" . }}-kubeconfig $LABELS
+                kubectl -n $NAMESPACE annotate secret {{ include "konk-service.fullname" . }}-kubeconfig \
+                  meta.helm.sh/release-name={{ .Release.Name }} \
+                  meta.helm.sh/release-namespace={{ .Release.Namespace }} --overwrite
                 # FIXME: set owner as deployment UID
                 DEPLOYMENT_UID=$(kubectl -n $NAMESPACE get deploy {{ include "konk-service.fullname" . }}-kubeconfig -o jsonpath='{.metadata.uid}')
                 echo "Found UID: $DEPLOYMENT_UID"
@@ -79,6 +82,9 @@ spec:
                   --from-file=/tmp/certs/tls.crt \
                   --from-file=/tmp/certs/tls.key \
                   --dry-run=client -o yaml | kubectl apply -f -
+                kubectl -n $NAMESPACE annotate secret {{ include "konk-service.fullname" . }}-kubeconfig \
+                  meta.helm.sh/release-name={{ .Release.Name }} \
+                  meta.helm.sh/release-namespace={{ .Release.Namespace }} --overwrite
                 md5sum /tmp/certs/* > /tmp/certsum
               )
               fi

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubeconfig
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/kubeconfig-rbac.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-rbac.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubeconfig
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 rules:
@@ -29,6 +31,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "konk-service.fullname" . }}-kubeconfig
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
 roleRef:

--- a/helm-charts/konk-service/templates/serviceaccount.yaml
+++ b/helm-charts/konk-service/templates/serviceaccount.yaml
@@ -5,10 +5,11 @@ metadata:
   name: {{ include "konk-service.serviceAccountName" . }}
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- if .Values.space.enabled }}
 imagePullSecrets:
 - name: {{ template "konk-service.fullname" $ }}-imagepullsecret

--- a/helm-charts/konk-service/templates/space.yaml
+++ b/helm-charts/konk-service/templates/space.yaml
@@ -6,6 +6,8 @@ kind: Space
 metadata:
   name: {{ template "konk-service.fullname" $ }}-{{ lower $key }}
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- include "konk-service.helmAnnotations" $ | nindent 4 }}
   labels:
     {{- include "konk-service.labels" $ | nindent 4 }}
 spec:

--- a/helm-charts/konk-service/templates/tests/test-setup.yaml
+++ b/helm-charts/konk-service/templates/tests/test-setup.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "konk-service.labels" . | nindent 4 }}
   annotations:
+    {{- include "konk-service.helmAnnotations" . | nindent 4 }}
     "helm.sh/hook": test-success
     "helm.sh/hook": test
 spec:

--- a/helm-charts/konk/scripts/provision.sh
+++ b/helm-charts/konk/scripts/provision.sh
@@ -110,6 +110,9 @@ then
   kubectl -n $NAMESPACE create secret generic $FULLNAME-kubeconfig \
     --from-file=/etc/kubernetes/admin.conf
   kubectl -n $NAMESPACE label secret $FULLNAME-kubeconfig $LABELS
+  kubectl -n $NAMESPACE annotate secret $FULLNAME-kubeconfig \
+    meta.helm.sh/release-name=$RELEASE \
+    meta.helm.sh/release-namespace=$NAMESPACE --overwrite
 fi
 
 kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.apps -l app.kubernetes.io/instance=$RELEASE
@@ -117,5 +120,8 @@ kubectl -n $NAMESPACE wait --timeout=3m --for=condition=progressing deployments.
 DEPLOYMENT_UID=$(kubectl get deployments.apps -n $NAMESPACE $FULLNAME -o jsonpath='{.metadata.uid}')
 for name in $FULLNAME-apiserver-cert $FULLNAME-etcd-cert $FULLNAME-ca $FULLNAME-etcd-ca $FULLNAME-kubeconfig
 do
+  kubectl annotate -n $NAMESPACE secret $name \
+    meta.helm.sh/release-name=$RELEASE \
+    meta.helm.sh/release-namespace=$NAMESPACE --overwrite
   kubectl patch -n $NAMESPACE secret $name -p '{"metadata":{"ownerReferences":[{"apiVersion":"apps/v1", "kind":"Deployment", "name":"'${FULLNAME}'", "uid":"'${DEPLOYMENT_UID}'"}]}}'
 done

--- a/helm-charts/konk/templates/_helpers.tpl
+++ b/helm-charts/konk/templates/_helpers.tpl
@@ -103,3 +103,13 @@ dummy
 {{- fail "cert-manager CRD does not appear to be installed" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Helm ownership annotations — ensures resources can be adopted after release secret loss.
+Without these, a fresh helm install will fail with "cannot be imported" if the
+operator loses its release state (e.g. after an upgrade or ownerRef GC).
+*/}}
+{{- define "konk.helmAnnotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm-charts/konk/templates/configmap.yaml
+++ b/helm-charts/konk/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "konk.fullname" . }}-scripts
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 data:

--- a/helm-charts/konk/templates/deployment.yaml
+++ b/helm-charts/konk/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "konk.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/etcd.yaml
+++ b/helm-charts/konk/templates/etcd.yaml
@@ -5,6 +5,8 @@ kind: Etcd
 metadata:
   name: {{ $.Release.Name }}-etcd
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" $ | nindent 4 }}
   labels:
     {{- include "konk.labels" $ | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/hpa.yaml
+++ b/helm-charts/konk/templates/hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "konk.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/ingress-client-certs.yaml
+++ b/helm-charts/konk/templates/ingress-client-certs.yaml
@@ -5,6 +5,8 @@ metadata:
   {{- if eq .Values.scope "namespace" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
@@ -16,6 +18,8 @@ kind: Certificate
 metadata:
   name: {{ include "konk.fullname" . }}-ingress-client
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/ingress-client-certs.yaml
+++ b/helm-charts/konk/templates/ingress-client-certs.yaml
@@ -24,6 +24,9 @@ metadata:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk.fullname" . }}-ingress-client
+  secretTemplate:
+    annotations:
+      {{- include "konk.helmAnnotations" . | nindent 6 }}
   # SubjectAltName
   # TODO: change to view, update RBAC to allow view
   subject:

--- a/helm-charts/konk/templates/ingress.yaml
+++ b/helm-charts/konk/templates/ingress.yaml
@@ -17,12 +17,13 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.Version) }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/helm-charts/konk/templates/init.yaml
+++ b/helm-charts/konk/templates/init.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "konk.fullname" . }}-init
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/requestheader.yaml
+++ b/helm-charts/konk/templates/requestheader.yaml
@@ -7,6 +7,8 @@ kind: Issuer
 metadata:
   name: {{ include "konk.fullname" . }}-requestheader-self-signed
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
@@ -17,6 +19,8 @@ kind: Certificate
 metadata:
   name: {{ include "konk.fullname" . }}-requestheader-self-signed
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
@@ -37,6 +41,8 @@ metadata:
   {{- if eq .Values.scope "namespace" }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
@@ -48,6 +54,8 @@ kind: Certificate
 metadata:
   name: {{ include "konk.fullname" . }}-requestheader-proxy-client
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
     component: proxy-client

--- a/helm-charts/konk/templates/requestheader.yaml
+++ b/helm-charts/konk/templates/requestheader.yaml
@@ -25,6 +25,9 @@ metadata:
     {{- include "konk.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "konk.fullname" . }}-requestheader-self-signed
+  secretTemplate:
+    annotations:
+      {{- include "konk.helmAnnotations" . | nindent 6 }}
   duration: 17520h #2y
   issuerRef:
     name: {{ include "konk.fullname" . }}-requestheader-self-signed
@@ -61,6 +64,9 @@ metadata:
     component: proxy-client
 spec:
   secretName: {{ include "konk.fullname" . }}-proxy-client
+  secretTemplate:
+    annotations:
+      {{- include "konk.helmAnnotations" . | nindent 6 }}
   # SubjectAltName
   # TODO: change to view, update RBAC to allow view
   subject:

--- a/helm-charts/konk/templates/role.yaml
+++ b/helm-charts/konk/templates/role.yaml
@@ -3,6 +3,8 @@ kind: {{ include "konk.scope" . }}Role
 metadata:
   name: {{ include "konk.fullname" . }}-certs-role
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 rules:

--- a/helm-charts/konk/templates/rolebinding.yaml
+++ b/helm-charts/konk/templates/rolebinding.yaml
@@ -3,6 +3,8 @@ kind: {{ include "konk.scope" . }}RoleBinding
 metadata:
   name: {{ include "konk.fullname" . }}-certs-rb
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 roleRef:

--- a/helm-charts/konk/templates/service.yaml
+++ b/helm-charts/konk/templates/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: {{ include "konk.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/serviceaccount.yaml
+++ b/helm-charts/konk/templates/serviceaccount.yaml
@@ -6,10 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konk.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- if .Values.space.enabled }}
 imagePullSecrets:
 - name: {{ template "konk.fullname" $ }}-imagepullsecret

--- a/helm-charts/konk/templates/space.yaml
+++ b/helm-charts/konk/templates/space.yaml
@@ -6,6 +6,8 @@ kind: Space
 metadata:
   name: {{ template "konk.fullname" $ }}-{{ lower $key }}
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- include "konk.helmAnnotations" $ | nindent 4 }}
   labels:
     {{- include "konk.labels" $ | nindent 4 }}
 spec:

--- a/helm-charts/konk/templates/tests/test-connection.yaml
+++ b/helm-charts/konk/templates/tests/test-connection.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "konk.labels" . | nindent 4 }}
   annotations:
+    {{- include "konk.helmAnnotations" . | nindent 4 }}
     "helm.sh/hook": test-success
     "helm.sh/hook": test
 spec:


### PR DESCRIPTION
## Summary

Add `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations to all rendered resources in the `konk` and `konk-service` Helm charts.

## Problem

After operator upgrades or any event that causes Helm release state to be re-created, the operator can do a fresh `helm install`. In the observed stage failure, some `KonkService` releases created by the install path had live resources missing Helm ownership annotations. This later causes reconcile/import failures such as:

```text
cannot be imported into the current release: invalid ownership metadata; missing key "meta.helm.sh/release-name"
```

The health check then reports `konk-service Deployment(s) missing meta.helm.sh/release-name annotation`, requiring a manual annotation repair script.

## Evidence from us-stg-1

- Helm release secrets exist and are `status: deployed`.
- Helm release manifests do not store `meta.helm.sh` annotations, which is normal Helm behavior because those annotations are injected at apply time.
- Releases that only went through fresh Install (`v1`) had missing annotations on live kubeconfig Deployments.
- Releases that later went through Upgrade (`v2`/`v3`) had correct annotations on live resources.

## Fix

Include the Helm ownership annotations directly in the rendered chart templates through shared helpers:

- `konk.helmAnnotations`
- `konk-service.helmAnnotations`

This makes the rendered manifests self-contained and ensures both fresh Install and Upgrade paths apply the ownership metadata.

## Impact

- No pod restarts: only top-level resource metadata annotations change, not pod template annotations.
- No downtime: Kubernetes patches resources rather than recreating Deployments.
- Self-healing: the chart content change causes the operator to upgrade existing releases, applying missing annotations.
- Prevents recurrence: future fresh installs include ownership metadata in the rendered manifests.

## Changed Files

29 chart template files were updated across:

- `helm-charts/konk-service/templates/`
- `helm-charts/konk-service/templates/tests/`
- `helm-charts/konk/templates/`
- `helm-charts/konk/templates/tests/`

Coverage now includes Deployments, Services, ConfigMaps, ServiceAccounts, RBAC, cert-manager resources, Space resources, Ingresses, Jobs, HPA, and Helm test pods.

## Testing

Rendered both charts with optional paths enabled and verified every rendered resource has both Helm ownership annotations.

```bash
helm template test-konk helm-charts/konk-service \
  --set konk.name=test-konk \
  --set konk.namespace=aggregate \
  --set isLint=true \
  --set space.enabled=true \
  --set vaultCommon.imagepullsecret.path=/image-pull/infobloxctokey \
  --set ingress.enabled=true
# OK: no missing annotations

helm template test-konk helm-charts/konk \
  --set isLint=true \
  --set scope=namespace \
  --set certManager.namespace=cert-manager \
  --set space.enabled=true \
  --set vaultCommon.imagepullsecret.path=/image-pull/infobloxctokey \
  --set autoscaling.enabled=true \
  --set ingress.enabled=true
# OK: no missing annotations
```

Additional checks:

```bash
git diff --check
helm lint helm-charts/konk-service --set konk.name=test-konk --set konk.namespace=aggregate --set isLint=true --set space.enabled=true --set vaultCommon.imagepullsecret.path=/image-pull/infobloxctokey --set ingress.enabled=true
```

`konk-service` lint passed. `konk` lint completed with 0 failures, but emits pre-existing warnings because `helm lint` uses the default release name `test-release` while this chart expects release names ending in `-konk`.
