### PR TITLE
fix(etcd): always recreate STS when hook enabled to prevent strategic merge issues

### DIFF
--- a/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
+++ b/helm-charts/etcd/templates/recreate-statefulset-hook.yaml
@@ -5,11 +5,15 @@ update and the Helm operator loops in a failed-upgrade / rollback cycle. This
 pre-upgrade hook deletes the existing StatefulSet so Helm recreates it with the
 new claimName (a CREATE, which has no immutable-field restriction).
 
-It is gated two ways so it is safe to leave enabled:
-  1. recreateStatefulSet.enabled must be true, AND
-  2. the LIVE StatefulSet's volumeClaimTemplate name must differ from the desired
-     persistence.claimName (looked up at render time).
-Once migrated, the live claimName matches the target and the hook renders nothing.
+It also prevents strategic merge patch issues when upgrading between chart
+variants (e.g. Bitnami → upstream). A strategic merge on the env array can
+merge conflicting fields (value + valueFrom on the same env var), causing pod
+creation failures. Deleting the STS forces a fresh CREATE that uses the chart's
+clean template without merge artifacts.
+
+The hook is gated by recreateStatefulSet.enabled, which is manually set for
+migration and removed after. It fires whenever a live StatefulSet exists, so it
+is safe: once disabled, the hook renders nothing.
 
 Existing PVCs are retained (StatefulSet PVCs are not garbage-collected on delete),
 so the old volumes remain available as a backup.
@@ -22,7 +26,7 @@ so the old volumes remain available as a backup.
 {{- if and $live $live.spec.volumeClaimTemplates }}
 {{- $currentClaim = (index $live.spec.volumeClaimTemplates 0).metadata.name }}
 {{- end }}
-{{- if and $currentClaim (ne $currentClaim $target) }}
+{{- if $currentClaim }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Problem

When upgrading from the old Bitnami etcd chart to the new upstream chart, the Helm operator's strategic merge patch can merge conflicting env var fields (`value` + `valueFrom`) on the `ETCD_NAME` entry, producing:

```yaml
- name: ETCD_NAME
  value: "$(MY_POD_NAME)"         # stale, from old Bitnami STS
  valueFrom:                      # new, from upstream chart
    fieldRef:
      fieldPath: metadata.name
```

Kubernetes rejects this at pod creation: `"may not be specified when value is not empty"`.

**Observed on:** us-stg-1 during etcd PVC migration (DC PR #134685).  
**Not observed on:** us-dev-5 — the pre-upgrade hook fired before the merge, forcing a clean CREATE.

## Root Cause

The `recreateStatefulSet` pre-upgrade hook deletes the old STS before Helm applies the new one, forcing a CREATE (no strategic merge). However, the hook previously only fired when the VCT name differed from the target. In some cases, the operator's reconcile loop patches the STS (strategic merge) before the hook fires, causing the env var conflict.

## Fix

Widen the hook condition: fire whenever `recreateStatefulSet.enabled=true` **and** a live StatefulSet exists, regardless of whether the VCT name has changed. This guarantees the DELETE+CREATE path and eliminates the strategic merge artifact.

```diff
- {{- if and $currentClaim (ne $currentClaim $target) }}
+ {{- if $currentClaim }}
```

The hook remains gated by `recreateStatefulSet.enabled`, which is manually set for migration and removed after — safe for normal operations.

## Testing

- [x] Verified on us-stg-1 — the recreated STS had clean env vars (only `valueFrom`)
- [ ] Deploy to us-dev-4 with this fix to confirm no manual patch needed