### PR TITLE
ci: add go-vuln-remediate skill and daily auto-fix workflow

### DIFF
--- a/.github/skills/go-vuln-remediate/SKILL.md
+++ b/.github/skills/go-vuln-remediate/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: go-vuln-remediate
+description: 'Run Wiz-based vulnerability scan and automatic Go module remediation for containerized Go services in the konk repository. Use when you need to build images, scan CVEs, patch vulnerable dependencies in go.mod/go.sum across konk-service and konk-provision modules, validate builds, and prepare a PR summary.'
+argument-hint: 'Provide image targets (name|dockerfile|build_path|image_tag|module_dir), base image, and registry/auth constraints.'
+user-invocable: true
+---
+
+# Go Wiz Auto Vulnerability Fix (konk)
+
+## Purpose
+This skill converts the GitHub Actions workflow behavior into an agent-driven runbook for local or CI-assisted execution.
+It helps you:
+- Build Go binaries and Docker images for scan.
+- Run Wiz scanner against the built images.
+- Parse Wiz output into structured findings.
+- Recommend the safest compatible fix version for each package.
+- Score exploit urgency versus fix risk and allowlist low-risk fixes.
+- Apply only allowlisted dependency updates, per Go module.
+- Rebuild to validate no regressions.
+- Produce PR-ready markdown summaries for fixes, skipped items, and manual follow-ups.
+
+## Repository Layout (multi-module)
+konk has **no root `go.mod`**. Each scanned image is built from its own Go module:
+
+| Target | Module dir | Dockerfile | Image tag |
+|---|---|---|---|
+| `konk-service` | `cmd/konk-service` | `Dockerfile.konk-service` | `konk-service` |
+| `konk-provision` | `cmd/provision` | `Dockerfile.provision` | `konk-provision` |
+
+Out of scope for auto-fix (must be remediated manually):
+- The konk operator image (root `Dockerfile`) builds `operator-sdk` `helm-operator` from upstream source — CVEs require bumping the pinned `operator-sdk` tag in the Dockerfile.
+- The konk-app image (`build/kubernetes/Dockerfile`) is a patched kube-apiserver fork — CVEs require bumping `K8S_RELEASE` in the Makefile.
+
+## When to Use
+Use this skill when one or more konk Go services have vulnerability findings and you want repeatable, semi-automated remediation with guardrails.
+
+## Required Inputs
+Collect these before execution:
+- Service config values (all sourced from `.github/skills/go-vuln-remediate/konk/service-config.env`):
+  - `IMAGE_NAME`, `DOCKERFILE_PATH`, `SERVER_BUILD_PATH` — defaults that describe the first target
+  - `SCAN_TARGETS` — `;`-separated list of images to build and scan; each entry is `name|dockerfile|build_path|image_tag|module_dir`. konk scans two images (`konk-service`, `konk-provision`); findings from all images are merged before risk scoring, and the resulting allowlist is applied per-module.
+  - `BUILD_TAGS`, `BUILD_LDFLAGS`, `DOCKER_BUILD_EXTRA_ARGS`
+  - `BASE_IMAGE`
+  - `GO_PRIVATE`
+  - `MODE` — risk scoring mode (heuristic only)
+  - `RISK_THRESHOLD_AUTO` — score below this can be auto-applied
+  - `RISK_THRESHOLD_REVIEW` — score below this requires review instead of skip
+  - `MIN_CONFIDENCE` — minimum confidence required for `auto_apply`
+  - `EXPLOIT_WEIGHT` — weight for severity/exploit score
+  - `VERSION_WEIGHT` — weight for version safety score
+  - `CYCLE_WEIGHT` — weight for urgency / time-to-fix score
+  - The bundled `konk/service-config.env` is a template with repo-specific defaults. Copy it locally or override values in your environment before running the skill outside CI.
+- Credentials/tokens (if scanning private images or repos):
+  - Wiz client id/secret (`WIZ_CLIENT_ID` / `WIZ_CLIENT_SECRET`)
+  - Registry username/password (`HARBOR_SERVICES_PROD_USERNAME` / `HARBOR_SERVICES_PROD_PASSWORD`)
+  - Git token with private module access (`GITPAT`)
+
+Use [workflow mapping](./references/workflow-mapping.md) as the canonical behavior reference.
+
+## Procedure
+1. Ensure you are at the root of the repo. konk has no root `go.mod`; each module lives under `cmd/<target>/`.
+2. Build Docker image(s) for scanning. Iterate every entry in `SCAN_TARGETS` and build each image as `<image_tag>:scan`:
+   - `bash -lc 'set -euo pipefail; source .github/skills/go-vuln-remediate/konk/service-config.env; IFS=";" read -r -a TARGETS <<< "$SCAN_TARGETS"; for e in "${TARGETS[@]}"; do IFS="|" read -r n d b img m <<< "$e"; echo "Building $img:scan from $d"; docker build --progress=plain -f "$d" --build-arg BASE_IMAGE="$BASE_IMAGE" $DOCKER_BUILD_EXTRA_ARGS -t "$img:scan" .; done'`
+   - Note: wrapping in `bash -lc` prevents zsh strict-mode/RPROMPT hook errors when `DOCKER_BUILD_EXTRA_ARGS` contains multiple `--build-arg` flags.
+3. Select scanner and scan each target image — choose the first available path:
+    - **Wiz (primary, workflow parity)** — if `WIZ_CLIENT_ID` and `WIZ_CLIENT_SECRET` are both set:
+       - Install `wizcli` (workflow behavior): `curl -sL --fail -o wizcli "https://downloads.wiz.io/v1/wizcli/${WIZ_CLI_VERSION}/wizcli-linux-amd64" && chmod +x wizcli && sudo mv wizcli /usr/local/bin/wizcli`
+     - Authenticate: `wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"`
+     - Scan each target to a per-image JSON file `wiz-scan-results-<name>.json`: `wizcli docker scan -i "<image_tag>:scan" -p "PSE: Vulnerability - Critical - Audit/Warn - All Projects" -p "PSE: Vulnerability - High - Audit/Warn - All Projects" --json-output-file "wiz-scan-results-<name>.json" --file-hashes-scan`
+       - Parse all JSON files together with [Wiz JSON parser](./scripts/wiz-json-parse.sh) (it accepts multiple inputs and unions findings): `.github/skills/go-vuln-remediate/scripts/wiz-json-parse.sh wiz-scan-results-*.json --parsed parsed-vulns.txt --cve-map cve-map.txt --cve-version-map cve-version-map.txt`.
+    - **Grype (fallback)** — if Wiz credentials are absent or Wiz scan cannot run, and `command -v grype` succeeds:
+       - Run [grype parser](./scripts/grype-parse.sh) per image and merge outputs.
+   - **No scanner available** — if no valid scanner path above can run:
+     - Print: `"No scanner available: wizcli is not installed or Wiz credentials are missing, and grype is not installed. Stopping."` and exit.
+4. Recommend the safest compatible fix version for each package:
+   - `bash .github/skills/go-vuln-remediate/scripts/version-selector.sh parsed-vulns.txt version-recommendations.jsonl`
+5. Score exploit urgency versus time-to-fix and build the auto-apply allowlist:
+   - `bash -lc 'set -euo pipefail; source .github/skills/go-vuln-remediate/konk/service-config.env; bash .github/skills/go-vuln-remediate/scripts/risk-score.sh --input parsed-vulns.txt --recommendations version-recommendations.jsonl --output risk-decisions.jsonl --mode "$MODE" --auto-threshold "$RISK_THRESHOLD_AUTO" --review-threshold "$RISK_THRESHOLD_REVIEW" --min-confidence "$MIN_CONFIDENCE" --confidence "$CONFIDENCE" --exploit-weight "$EXPLOIT_WEIGHT" --version-weight "$VERSION_WEIGHT" --cycle-weight "$CYCLE_WEIGHT"'`
+   - `jq -r 'select(.decision=="auto_apply") | "\(.package)\t\(.fixed_version)"' risk-decisions.jsonl > allowlist.txt`
+6. Apply only allowlisted fixes **per module**. The shared allowlist is replayed against every module that has the affected package as a direct or indirect requirement:
+   - `WORK="$PWD"`
+   - For each `SCAN_TARGETS` entry, capture `module_dir`, then run inside that directory with absolute artifact paths:
+     - `cd "$module_dir" && "${WORK}/.github/skills/go-vuln-remediate/scripts/parse-fix.sh" --mode apply --parsed "${WORK}/parsed-vulns.txt" --recommendations "${WORK}/version-recommendations.jsonl" --allowlist "${WORK}/allowlist.txt" --summary "${WORK}/vuln-fix-summary-<name>.md"`
+   - Concatenate per-module summaries into `vuln-fix-summary.md`, prefixing each section with a `### Module: <module_dir>` heading.
+7. If fixes were applied, run build validation per module using the same flags:
+   - `cd "$module_dir" && CGO_ENABLED=0 go build -v -tags "$BUILD_TAGS" -trimpath -ldflags "$BUILD_LDFLAGS" -o "${WORK}/bin/<name>" "$build_path"`
+8. Generate final artifacts for review. If fixes were applied, commit the changed `go.mod` and `go.sum` files **in each affected module dir** on a new branch and open a PR:
+   - `vuln-fix-summary.md`
+   - `parsed-vulns.txt`
+   - `cve-map.txt`
+   - `cve-version-map.txt`
+   - `version-recommendations.jsonl`
+   - `risk-decisions.jsonl`
+   - `allowlist.txt`
+   - updated `cmd/konk-service/go.mod`, `cmd/konk-service/go.sum`, `cmd/provision/go.mod`, `cmd/provision/go.sum` when successful
+
+   Note: konk modules do not commit `vendor/`. `parse-fix.sh` will run `go mod tidy && go mod vendor` locally as a validation step but only `go.mod` and `go.sum` are committed to the PR.
+
+## Guardrails Included
+- Skips dependency updates with large minor-version jumps (>10).
+- Captures packages with no available fixed version (including EOL-TECHNOLOGY findings).
+- Preserves full package names (including names with spaces) during parse and summary generation using tab-delimited records.
+- Distinguishes stdlib findings from module findings.
+- Reverts `go.mod` **and** `go.sum` if `go mod download` fails for a package.
+- Reverts all dependency changes (in the current module dir) if `go mod tidy` or `go mod vendor` fails.
+- Includes findings requiring manual remediation regardless of domain suffix pattern.
+- Detects transitive dependencies via `go mod graph`; transitive packages requiring manual remediation report their importing repos.
+- Tracks CVEs per package **and** per fixed version (`cve-map.txt`, `cve-version-map.txt`).
+- When multiple fix versions are suggested for a package: all are shown in the summary for visibility, but only the recommended allowlisted target is actually applied.
+- Uses risk scoring to separate `auto_apply`, `review_required`, and `skip_auto` candidates before any dependency change.
+- Scanner selection: workflow parity installs `wizcli` at runtime when Wiz credentials are present, then scans/parses JSON output. Grype is used as fallback when Wiz cannot run and `grype` is installed; if neither path is available execution stops with an error message. All scanner paths produce identical `parsed-vulns.txt`/`cve-map.txt`/`cve-version-map.txt` output, and downstream recommendation/risk/apply steps are unchanged.
+- Multi-module safety: the shared allowlist is applied independently inside each module's directory; modules that don't require an affected package are left untouched by `parse-fix.sh`'s direct/indirect detection.
+
+## Output Contract
+The skill writes:
+- `vuln-fix-summary.md` — combined markdown summary, with per-module sections containing:
+  - **Packages Updated** — pipe-delimited table (`| Package | From | To | Severity | CVEs |`); rows marked `(applied)` or `(reported only)` when multiple fix versions exist for a package
+  - **Vulnerabilities Requiring Manual Remediation** — packages with no fix version; transitive ones include their importing repos
+  - **Skipped Large Version Jumps** — packages skipped due to >10 minor-version delta
+  - **Go Stdlib Update Required** — when `stdlib` findings are detected
+- `parsed-vulns.txt` — tab-delimited raw records (`PACKAGE\tVERSION\tFIX_VERSION\tSEVERITY\tCVE_ID`)
+- `cve-map.txt` — per-package CVE list (`PACKAGE\tCVE1, CVE2, ...`)
+- `cve-version-map.txt` — per-package-per-fixed-version CVE list (`PACKAGE@VERSION\tCVE1, CVE2, ...`)
+- `version-recommendations.jsonl` — version safety recommendations per package/version candidate
+- `risk-decisions.jsonl` — risk scoring output with `auto_apply`, `review_required`, or `skip_auto`
+- `allowlist.txt` — tab-delimited package/version pairs permitted for automatic apply
+
+## Resources
+- [parse and fix script](./scripts/parse-fix.sh)
+- [version selector](./scripts/version-selector.sh)
+- [risk scorer](./scripts/risk-score.sh)
+- [grype parser](./scripts/grype-parse.sh)
+- [wiz JSON parser](./scripts/wiz-json-parse.sh)
+- [workflow mapping](./references/workflow-mapping.md)
+- [service env template](./konk/service-config.env)

--- a/.github/skills/go-vuln-remediate/konk/service-config.env
+++ b/.github/skills/go-vuln-remediate/konk/service-config.env
@@ -1,0 +1,60 @@
+# Service-specific configuration for go-vuln-remediate
+# Repo: github.com/infobloxopen/konk
+
+# TARGET_BRANCH is configured via the GitHub Actions repository variable vars.TARGET_BRANCH.
+# Default: main
+WIZ_CLI_VERSION="latest"
+
+# Defaults below describe the first scan target (konk-service). When SCAN_TARGETS
+# contains multiple entries the workflow iterates and uses each entry's values.
+DOCKERFILE_PATH="Dockerfile.konk-service"
+SERVER_BUILD_PATH="."
+BUILD_TAGS=""
+BUILD_LDFLAGS="-s -w"
+DOCKER_BUILD_EXTRA_ARGS=""
+IMAGE_NAME="konk-service"
+BASE_IMAGE="gcr.io/distroless/static-debian12:nonroot"
+GO_PRIVATE="github.com/infobloxopen/*,github.com/Infoblox-CTO/*"
+
+# Images to build and scan. One entry per image, entries separated by ';'.
+# Each entry has five '|'-delimited fields: name|dockerfile|build_path|image_tag|module_dir
+#   name        unique short id used for per-image artifact file names
+#   dockerfile  path to the Dockerfile (relative to repo root) that produces the image
+#   build_path  Go main package built for the verify-after-fix step (relative to module_dir)
+#   image_tag   local image repository (scanned as <image_tag>:scan)
+#   module_dir  Go module root (relative to repo root) containing go.mod for this image
+#
+# Two Go services in this repo are scanned and auto-fixed:
+#   * konk-service     (cmd/konk-service/, Dockerfile.konk-service)
+#   * konk-provision   (cmd/provision/,    Dockerfile.provision)
+#
+# Out of scope for auto-fix:
+#   * konk operator image (root Dockerfile) — builds operator-sdk helm-operator
+#     from upstream source; CVEs require bumping the pinned operator-sdk tag.
+#   * konk-app image (build/kubernetes/Dockerfile) — patched kube-apiserver fork;
+#     CVEs require bumping K8S_RELEASE in the Makefile.
+SCAN_TARGETS="konk-service|Dockerfile.konk-service|.|konk-service|cmd/konk-service;konk-provision|Dockerfile.provision|.|konk-provision|cmd/provision"
+ARTIFACT_RETENTION_DAYS="30"
+
+# Optional registry credentials
+HARBOR_REGISTRY=harbor.services.sdp.infoblox.com
+# HARBOR_SERVICES_PROD_USERNAME=...
+# HARBOR_SERVICES_PROD_PASSWORD=...
+
+# Optional Wiz credentials
+# WIZ_CLIENT_ID=...
+# WIZ_CLIENT_SECRET=...
+
+# Risk scoring configuration
+MODE="heuristic"
+
+# Conservative gating
+RISK_THRESHOLD_AUTO="0.85"
+RISK_THRESHOLD_REVIEW="0.90"
+MIN_CONFIDENCE="0.70"
+CONFIDENCE="0.75"
+
+# Stability-biased weighting
+EXPLOIT_WEIGHT="0.40"
+VERSION_WEIGHT="0.35"
+CYCLE_WEIGHT="0.25"

--- a/.github/skills/go-vuln-remediate/references/workflow-mapping.md
+++ b/.github/skills/go-vuln-remediate/references/workflow-mapping.md
@@ -1,0 +1,107 @@
+# Workflow Mapping: GitHub Action -> Skill (konk)
+
+This document maps the konk CI workflow behavior to the skill-run procedure.
+
+## Step Mapping
+
+1. Resolve trigger and target branch
+- Workflow:
+  - Triggers on `schedule` and `workflow_dispatch`.
+  - Resolves target branch from repository variable `vars.TARGET_BRANCH`, defaulting to `main`.
+  - Runs remediation against the resolved target branch.
+- Skill:
+  - For local/manual runs, use the intended default branch (`main`) as remediation base.
+  - For CI parity, treat target branch as workflow-owned configuration (repository variable), not service-config-owned.
+
+2. Checkout and strict config loading
+- Workflow:
+  - Checks out the resolved target branch.
+  - Loads `.github/skills/go-vuln-remediate/konk/service-config.env` with strict `KEY=VALUE` parsing (no shell `source`).
+  - Exports defaults for build, scan, and risk-scoring variables.
+  - Exposes artifact retention as `artifact_retention_days` output (`ARTIFACT_RETENTION_DAYS`, default `30`).
+- Skill:
+  - Load equivalent variables with strict parsing behavior.
+  - Keep defaults aligned with workflow exports.
+
+3. Private module and Go environment bootstrap
+- Workflow:
+  - Configures optional private Git auth via `GITPAT` URL rewrite.
+  - Sets `GOPRIVATE` and `GONOSUMDB` when `GO_PRIVATE` is set.
+  - Sets `GOPROXY=https://proxy.golang.org,direct`.
+  - Uses `actions/setup-go@v5` with `go-version-file: cmd/konk-service/go.mod` (konk has no root `go.mod`).
+- Skill:
+  - Ensure equivalent auth/proxy setup before dependency or build steps.
+
+4. Build scan images (no pre-build Go binary)
+- Workflow:
+  - Iterates each entry in `SCAN_TARGETS` (`name|dockerfile|build_path|image_tag|module_dir`).
+  - For each entry: `docker build --progress=plain -f "$dockerfile" --build-arg BASE_IMAGE="$BASE_IMAGE" $DOCKER_BUILD_EXTRA_ARGS -t "$image_tag:scan" .`
+  - Each konk Dockerfile internally runs `go build` against its own module, so no separate pre-build is required.
+- Skill:
+  - Run the same docker build command per target with values from service config.
+
+5. Wiz guard, auth, and scan
+- Workflow:
+  - Installs CLI from `https://downloads.wiz.io/v1/wizcli/${WIZ_CLI_VERSION}/wizcli-linux-amd64` (version defaults to `latest` from `service-config.env`).
+  - Runs `wiz_guard`: if `WIZ_CLIENT_ID`/`WIZ_CLIENT_SECRET` are missing, skips auth+scan and reports reason in the step summary.
+  - If ready, authenticates and runs scan with Critical+High policies and `--file-hashes-scan` for each target.
+  - Writes results to `wiz-scan-results-<name>.json` and raw CLI output to `wiz-scan-raw-<name>.txt` (one pair per scan target).
+- Skill:
+  - Preserve guard behavior and reporting.
+  - Produce and retain per-target `wiz-scan-results-*.json` as parser input, and retain `wiz-scan-raw-*.txt` for scan evidence.
+
+6. Parse, recommend, score, and queue review
+- Workflow:
+  - Parses findings from all `wiz-scan-results-*.json` files together using [wiz-json-parse.sh](../scripts/wiz-json-parse.sh); findings are unioned across images.
+  - Recommends compatible fix versions using [version-selector.sh](../scripts/version-selector.sh).
+  - Scores risk using [risk-score.sh](../scripts/risk-score.sh) and writes `risk-decisions.jsonl`.
+  - Builds `review-queue.md` from `review_required` and `skip_auto` decisions.
+  - Builds `allowlist.txt` from `decision=="auto_apply"`.
+- Skill:
+  - Preserve the same file formats and decision flow before apply.
+
+7. Apply fixes per module and detect dependency diffs
+- Workflow:
+  - For each `SCAN_TARGETS` entry, `cd "$module_dir"` and call [parse-fix.sh](../scripts/parse-fix.sh) with `--mode apply` using absolute paths to the shared `parsed-vulns.txt`, `version-recommendations.jsonl`, and `allowlist.txt`, writing a per-module summary `vuln-fix-summary-<name>.md`.
+  - Concatenates per-module summaries into a single `vuln-fix-summary.md`, prefixing each section with the module name.
+  - Detects changes across all module dirs' `go.mod` and `go.sum`.
+- Skill:
+  - Keep identical per-module apply and diff-detection behavior.
+
+8. No-change reporting and build validation
+- Workflow:
+  - If no dependency changes: writes a workflow summary.
+  - If dependency changes: rebuilds each affected module with `cd "$module_dir" && CGO_ENABLED=0 go build ...` using the same flags, then records pass/fail status overall.
+- Skill:
+  - Provide explicit no-change messaging and per-module rebuild validation parity.
+
+9. Artifacts and PR automation
+- Workflow:
+  - Always uploads scan/decision artifacts and uses configurable retention days.
+  - Creates PR body from build status, remediation summary, and optional review queue.
+  - Cleans stale `auto-fix-vulns-daily` branch when no open PR exists.
+  - Creates/updates PR via `peter-evans/create-pull-request@v7`.
+  - Uses resolved target branch as PR base.
+  - `add-paths` includes `cmd/konk-service/go.mod`, `cmd/konk-service/go.sum`, `cmd/provision/go.mod`, `cmd/provision/go.sum`. Vendor directories are **not** committed (konk modules do not vendor dependencies).
+- Skill:
+  - Preserve equivalent artifacts and PR-ready summary content for manual or automated PR creation.
+
+## Behavior Preserved
+- Handles CVE and EOL-TECHNOLOGY severities.
+- Parses package records safely when package names contain spaces.
+- Tracks CVEs per package and per package+fixed-version.
+- Scores version safety before selecting a fix target.
+- Uses risk gating to build an allowlist of `auto_apply` package/version pairs.
+- Reports all candidate fixed versions and applies one allowlisted target.
+- Skips large/risky jumps per apply-time guards.
+- Marks stdlib findings for toolchain updates.
+- Includes manual-remediation findings in summary output.
+- Detects and annotates transitive dependency context for manual remediation.
+- Restores `go.mod` and `go.sum` (in the per-module dir) when package download fails.
+- Reverts dependency edits (`go.mod`, `go.sum`, `vendor/`) within a module when tidy/vendor fails for that module.
+- Skips Wiz scan gracefully when credentials are unavailable.
+
+## konk-specific notes
+- No root `go.mod`: every Go command lives under `cmd/<name>/` with its own module. The workflow always operates on per-target module directories declared in `SCAN_TARGETS`.
+- The konk operator image (root `Dockerfile`) is **not** included in `SCAN_TARGETS`. It builds operator-sdk's `helm-operator` from upstream source; CVEs require bumping the pinned operator-sdk tag.
+- The konk-app image (`build/kubernetes/Dockerfile`) is also **not** included. It packages a patched kube-apiserver fork; CVEs require bumping `K8S_RELEASE` in the Makefile and refreshing patches in `build/kubernetes/patches/`.

--- a/.github/skills/go-vuln-remediate/scripts/grype-parse.sh
+++ b/.github/skills/go-vuln-remediate/scripts/grype-parse.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Compatible with bash and zsh.
+[ -n "$ZSH_VERSION" ] && emulate bash
+set -euo pipefail
+
+# Grype fallback scanner — scans a container image and produces the same
+# tab-delimited artifacts as parse-fix.sh parse mode so that the rest of the
+# pipeline (version-selector.sh, risk-score.sh, parse-fix.sh apply mode) works
+# unchanged.
+#
+# Usage:
+#   ./grype-parse.sh <image> [options]
+#
+# Options:
+#   --parsed FILE          Output file for parsed vulns  (default: parsed-vulns.txt)
+#   --cve-map FILE         Output file for CVE map       (default: cve-map.txt)
+#   --cve-version-map FILE Output file for CVE-per-version map (default: cve-version-map.txt)
+#   --grype-output FILE    Raw Grype JSON output file    (default: grype-scan-output.json)
+#   --severities LIST      Comma-separated severities to include for fixable findings (default: Critical,High,Medium,Low)
+#                          Non-fixable findings are always included for manual remediation.
+#
+# Output format (matches parse-fix.sh):
+#   parsed-vulns.txt     — PACKAGE\tVERSION\tFIX_VERSION\tSEVERITY\tCVE_ID
+#   cve-map.txt          — PACKAGE\tCVE1, CVE2, ...
+#   cve-version-map.txt  — PACKAGE@FIXVERSION\tCVE1, CVE2, ...
+
+IMAGE="${1:-}"
+if [[ -z "$IMAGE" ]]; then
+  echo "Usage: $0 <image> [options]" >&2
+  exit 1
+fi
+shift
+
+PARSED_FILE="parsed-vulns.txt"
+CVE_MAP_FILE="cve-map.txt"
+CVE_VERSION_MAP_FILE="cve-version-map.txt"
+GRYPE_JSON="grype-scan-output.json"
+SEVERITIES="Critical,High,Medium,Low"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parsed)          PARSED_FILE="${2:-}";          shift 2 ;;
+    --cve-map)         CVE_MAP_FILE="${2:-}";          shift 2 ;;
+    --cve-version-map) CVE_VERSION_MAP_FILE="${2:-}";  shift 2 ;;
+    --grype-output)    GRYPE_JSON="${2:-}";            shift 2 ;;
+    --severities)      SEVERITIES="${2:-}";            shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 <image> [options]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Build severity allowlist JSON (uppercased) for jq matching.
+SEVERITY_JSON=$(printf '%s' "$SEVERITIES" | tr ',' '\n' | \
+  awk '{gsub(/^[[:space:]]+|[[:space:]]+$/, ""); if (length($0)>0) print toupper($0)}' | \
+  jq -R . | jq -s .)
+
+echo "Running Grype scan on $IMAGE ..."
+
+# Write scan output to a temp file first so failed scans do not clobber prior JSON.
+TMP_GRYPE_JSON=$(mktemp)
+if grype "$IMAGE" -o json --file "$TMP_GRYPE_JSON"; then
+  mv "$TMP_GRYPE_JSON" "$GRYPE_JSON"
+else
+  rm -f "$TMP_GRYPE_JSON"
+  exit 1
+fi
+
+if [[ ! -s "$GRYPE_JSON" ]]; then
+  echo "Grype produced empty output for $IMAGE" >&2
+  exit 1
+fi
+
+echo "Parsing Grype JSON output ..."
+
+: > "$PARSED_FILE"
+: > "$CVE_MAP_FILE"
+: > "$CVE_VERSION_MAP_FILE"
+
+# ── parsed-vulns.txt ─────────────────────────────────────────────────────────
+# Format: PACKAGE\tVERSION\tFIX_VERSION\tSEVERITY\tCVE_ID
+# Only go-module artifacts; strip leading 'v' from versions to match Wiz behaviour.
+jq -r --argjson severities "$SEVERITY_JSON" '
+  .matches[]
+  | (.vulnerability.severity | ascii_upcase) as $sev
+  | select(
+      .artifact.type == "go-module"
+      and (
+        ($severities | index($sev)) != null
+        or .vulnerability.fix.state != "fixed"
+      )
+    )
+  | [
+      .artifact.name,
+      (.artifact.version | ltrimstr("v")),
+      (if (.vulnerability.fix.state == "fixed" and (.vulnerability.fix.versions | length) > 0)
+       then (.vulnerability.fix.versions[0] | ltrimstr("v"))
+       else "NONE" end),
+      $sev,
+      .vulnerability.id
+    ]
+  | @tsv
+' "$GRYPE_JSON" | sort -u >> "$PARSED_FILE"
+
+TOTAL=$(wc -l < "$PARSED_FILE" | tr -d ' ')
+echo "Parsed $TOTAL vulnerability records into $PARSED_FILE"
+
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "No matching vulnerabilities found."
+  exit 0
+fi
+
+# ── cve-map.txt ───────────────────────────────────────────────────────────────
+# Format: PACKAGE\tCVE1, CVE2, ...
+awk -F'\t' '
+  NF >= 5 && $1 != "" && $5 != "" && !seen[$1 SUBSEP $5]++ {
+    if (list[$1] != "") list[$1] = list[$1] ", " $5
+    else list[$1] = $5
+  }
+  END {
+    for (pkg in list) print pkg "\t" list[pkg]
+  }
+' "$PARSED_FILE" | sort > "$CVE_MAP_FILE"
+
+# ── cve-version-map.txt ───────────────────────────────────────────────────────
+# Format: PACKAGE@FIXVERSION\tCVE1, CVE2, ...  (fixable entries only)
+awk -F'\t' '
+  NF >= 5 && $3 != "" && $3 != "NONE" {
+    key = $1 "@" $3
+    cve = $5
+    if (key != "" && cve != "" && !seen[key SUBSEP cve]++) {
+      if (list[key] != "") list[key] = list[key] ", " cve
+      else list[key] = cve
+    }
+  }
+  END {
+    for (key in list) print key "\t" list[key]
+  }
+' "$PARSED_FILE" | sort > "$CVE_VERSION_MAP_FILE"
+
+echo "CVE maps written: $CVE_MAP_FILE, $CVE_VERSION_MAP_FILE"

--- a/.github/skills/go-vuln-remediate/scripts/parse-fix.sh
+++ b/.github/skills/go-vuln-remediate/scripts/parse-fix.sh
@@ -1,0 +1,664 @@
+#!/usr/bin/env bash
+# Compatible with bash and zsh. When invoked via `zsh script.sh`, emulate bash
+# to normalise array indexing, word splitting, and option behaviour.
+[ -n "$ZSH_VERSION" ] && emulate bash
+set -euo pipefail
+
+# Usage:
+#   ./parse-fix.sh [--mode full|parse|apply] [options]
+# Options:
+#   --mode MODE                  full (default), parse, or apply
+#   --input FILE                 Wiz output file (default: wiz-scan-output.txt)
+#   --parsed FILE                Parsed vulns output (default: parsed-vulns.txt)
+#   --cve-map FILE               CVE map output (default: cve-map.txt)
+#   --cve-version-map FILE       CVE-per-version output (default: cve-version-map.txt)
+#   --allowlist FILE             Allowlist of package+version to apply (for apply mode)
+#   --recommendations FILE       Recommendations (optional, for apply mode)
+#   --summary FILE               Summary markdown output (default: vuln-fix-summary.md)
+
+MODE="full"
+WIZ_OUTPUT_FILE="wiz-scan-output.txt"
+SUMMARY_FILE="vuln-fix-summary.md"
+PARSED_FILE="parsed-vulns.txt"
+CVE_MAP_FILE="cve-map.txt"
+CVE_VERSION_MAP_FILE="cve-version-map.txt"
+ALLOWLIST_FILE=""
+RECOMMENDATIONS_FILE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="${2:-full}"; shift 2 ;;
+    --input) WIZ_OUTPUT_FILE="${2:-}"; shift 2 ;;
+    --parsed) PARSED_FILE="${2:-}"; shift 2 ;;
+    --cve-map) CVE_MAP_FILE="${2:-}"; shift 2 ;;
+    --cve-version-map) CVE_VERSION_MAP_FILE="${2:-}"; shift 2 ;;
+    --allowlist) ALLOWLIST_FILE="${2:-}"; shift 2 ;;
+    --recommendations) RECOMMENDATIONS_FILE="${2:-}"; shift 2 ;;
+    --summary) SUMMARY_FILE="${2:-}"; shift 2 ;;
+    -h|--help) 
+      echo "Usage: $0 [--mode MODE] [options]"
+      exit 0
+      ;;
+    *)
+      # Backward compatibility: first positional arg is wiz output file
+      if [[ -z "$WIZ_OUTPUT_FILE" ]] || [[ "$WIZ_OUTPUT_FILE" == "wiz-scan-output.txt" ]]; then
+        WIZ_OUTPUT_FILE="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+[[ "$MODE" =~ ^(full|parse|apply)$ ]] || { echo "Invalid --mode: $MODE" >&2; exit 2; }
+
+HAS_FIXES=false
+GO_MOD_CHANGED=false
+STDLIB_UPDATE_NEEDED=""
+STDLIB_CURRENT_VERSION=""
+STDLIB_FIXED_VERSION=""
+UNAVAILABLE=""
+MAJOR_JUMPS=""
+FIXED_LIST=""
+
+if [[ "$MODE" != "apply" ]] && [[ ! -f "$WIZ_OUTPUT_FILE" ]]; then
+  echo "No Wiz scan results found: $WIZ_OUTPUT_FILE"
+  exit 0
+fi
+
+# For parse/full modes, initialize and parse
+if [[ "$MODE" =~ ^(parse|full)$ ]]; then
+  : > "$PARSED_FILE"
+fi
+
+CURRENT_PKG=""
+CURRENT_VER=""
+CURRENT_SEV=""
+CURRENT_FIX="NONE"
+CURRENT_CVE=""
+
+# ====== PARSE PHASE (for parse/full modes) ======
+if [[ "$MODE" =~ ^(parse|full)$ ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" == *"Name:"*"Version:"* ]]; then
+      if [[ -n "$CURRENT_PKG" && -n "$CURRENT_SEV" ]]; then
+        printf "%s\t%s\t%s\t%s\t%s\n" "$CURRENT_PKG" "$CURRENT_VER" "$CURRENT_FIX" "$CURRENT_SEV" "$CURRENT_CVE" >> "$PARSED_FILE"
+      fi
+      CURRENT_PKG=$(echo "$line" | sed -n 's/.*Name: \([^,]*\), Version: \([^,]*\).*/\1/p')
+      CURRENT_VER=$(echo "$line" | sed -n 's/.*Name: \([^,]*\), Version: \([^,]*\).*/\2/p' | sed 's/^v//')
+      CURRENT_SEV=""
+      CURRENT_FIX="NONE"
+      CURRENT_CVE=""
+    elif [[ "$line" == *"CVE-"*"Severity:"* ]]; then
+      if [[ -n "$CURRENT_PKG" && -n "$CURRENT_SEV" ]]; then
+        printf "%s\t%s\t%s\t%s\t%s\n" "$CURRENT_PKG" "$CURRENT_VER" "$CURRENT_FIX" "$CURRENT_SEV" "$CURRENT_CVE" >> "$PARSED_FILE"
+      fi
+      CURRENT_CVE=$(echo "$line" | grep -oE 'CVE-[0-9]+-[0-9]+' | head -1)
+      CURRENT_SEV=$(echo "$line" | sed -n 's/.*Severity: \([A-Z]*\).*/\1/p')
+      CURRENT_FIX="NONE"
+    elif [[ "$line" == *"EOL-TECHNOLOGY"*"Severity:"* ]]; then
+      if [[ -n "$CURRENT_PKG" && -n "$CURRENT_SEV" ]]; then
+        printf "%s\t%s\t%s\t%s\t%s\n" "$CURRENT_PKG" "$CURRENT_VER" "$CURRENT_FIX" "$CURRENT_SEV" "$CURRENT_CVE" >> "$PARSED_FILE"
+      fi
+      CURRENT_CVE="EOL-TECHNOLOGY"
+      CURRENT_SEV=$(echo "$line" | sed -n 's/.*Severity: \([A-Z]*\).*/\1/p')
+      CURRENT_FIX="NONE"
+    elif [[ "$line" == *"Fixed version:"* ]]; then
+      CURRENT_FIX=$(echo "$line" | sed -n 's/.*Fixed version: *v*\([^ ]*\).*/\1/p')
+    fi
+  done < "$WIZ_OUTPUT_FILE"
+
+  if [[ -n "$CURRENT_PKG" && -n "$CURRENT_SEV" ]]; then
+    printf "%s\t%s\t%s\t%s\t%s\n" "$CURRENT_PKG" "$CURRENT_VER" "$CURRENT_FIX" "$CURRENT_SEV" "$CURRENT_CVE" >> "$PARSED_FILE"
+  fi
+
+  sort -u "$PARSED_FILE" -o "$PARSED_FILE"
+
+  if [[ ! -s "$PARSED_FILE" ]]; then
+    echo "No vulnerabilities parsed from $WIZ_OUTPUT_FILE"
+    [[ "$MODE" == "parse" ]] && exit 0
+  fi
+fi
+
+build_cve_maps_from_parsed() {
+  : > "$CVE_MAP_FILE"
+  : > "$CVE_VERSION_MAP_FILE"
+
+  # Package -> CVE list
+  awk -F'\t' '
+    NF>=5 {
+      pkg=$1
+      cve=$5
+      if (pkg!="" && cve!="" && !seen[pkg SUBSEP cve]++) {
+        if (list[pkg] != "") list[pkg] = list[pkg] ", " cve
+        else list[pkg] = cve
+      }
+    }
+    END {
+      for (pkg in list) {
+        print pkg "\t" list[pkg]
+      }
+    }
+  ' "$PARSED_FILE" | sort > "$CVE_MAP_FILE"
+
+  # Package@fixed_version -> CVE list (fixable only)
+  awk -F'\t' '
+    NF>=5 && $3!="" && $3!="NONE" {
+      key=$1 "@" $3
+      cve=$5
+      if (key!="" && cve!="" && !seen[key SUBSEP cve]++) {
+        if (list[key] != "") list[key] = list[key] ", " cve
+        else list[key] = cve
+      }
+    }
+    END {
+      for (key in list) {
+        print key "\t" list[key]
+      }
+    }
+  ' "$PARSED_FILE" | sort > "$CVE_VERSION_MAP_FILE"
+}
+
+# Parse mode should emit parsed output plus populated CVE map artifacts.
+if [[ "$MODE" == "parse" ]]; then
+  build_cve_maps_from_parsed
+  echo "Parse mode complete. Outputs: ${PARSED_FILE}, ${CVE_MAP_FILE}, ${CVE_VERSION_MAP_FILE}"
+  exit 0
+fi
+
+# For apply mode, parsed file must exist
+if [[ "$MODE" == "apply" ]] && [[ ! -s "$PARSED_FILE" ]]; then
+  echo "Apply mode requires existing parsed file: $PARSED_FILE" >&2
+  exit 1
+fi
+
+# Pre-populate CVE maps from the full parsed file so all lookups see complete data.
+build_cve_maps_from_parsed
+SEEN_NO_FIX_KEYS=""
+SEEN_APPLIED_KEYS=""
+SEEN_SUMMARY_KEYS=""
+# Read-only module introspection avoids go.sum churn when no fixes are applied.
+CURRENT_MODULE=$(GOFLAGS='-mod=readonly' go list -m -f '{{.Path}}' 2>/dev/null || true)
+ALL_MODULES_SORTED=""
+DIRECT_MODULES=""
+
+get_pkg_cves() {
+  local pkg="$1"
+  awk -F'\t' -v pkg="$pkg" '$1==pkg {print $2; found=1; exit} END {if (!found) print "N/A"}' "$CVE_MAP_FILE"
+}
+
+get_pkg_cves_for_version() {
+  local pkg="$1"
+  local fixed_ver="$2"
+  local key="${pkg}@${fixed_ver}"
+  awk -F'\t' -v key="$key" '$1==key {print $2; found=1; exit} END {if (!found) print "N/A"}' "$CVE_VERSION_MAP_FILE"
+}
+
+get_highest_fixed_version_for_pkg() {
+  local pkg="$1"
+  awk -F'\t' -v pkg="$pkg" '$1==pkg && $3!="NONE" && $3!="" {print $3}' "$PARSED_FILE" | sort -V | tail -1
+}
+
+version_lt() {
+  local a="$1"
+  local b="$2"
+  [[ "$a" == "$b" ]] && return 1
+  local first
+  first=$(printf '%s\n%s\n' "$a" "$b" | sort -V | head -1)
+  [[ "$first" == "$a" ]]
+}
+
+# Check if a package+version pair is in the allowlist (for apply mode)
+is_allowed() {
+  local pkg="$1"
+  local ver="$2"
+  [[ -z "$ALLOWLIST_FILE" ]] && return 0
+  [[ ! -f "$ALLOWLIST_FILE" ]] && return 1
+  awk -F'\t' -v p="$pkg" -v v="$ver" '$1==p && $2==v {found=1} END{exit(found?0:1)}' "$ALLOWLIST_FILE"
+}
+
+# Get recommended version from recommendations file (for apply mode)
+get_recommended_version() {
+  local pkg="$1"
+  local default_ver="$2"
+  [[ -z "$RECOMMENDATIONS_FILE" ]] && echo "$default_ver" && return
+  [[ ! -f "$RECOMMENDATIONS_FILE" ]] && echo "$default_ver" && return
+  local rec
+  rec=$(jq -rs -r --arg pkg "$pkg" '
+    def parts(v):
+      (v | tostring | ltrimstr("v") | split(".") | map(tonumber? // 0)) as $p
+      | [($p[0] // 0), ($p[1] // 0), ($p[2] // 0)];
+    [ .[]
+      | select(.package==$pkg and .recommended_version != null and .recommended_version != "")
+      | {version: .recommended_version, safety: (.safety_score // 0)}
+    ]
+    | if length == 0 then ""
+      else
+        (sort_by(.safety, (parts(.version)[0]), (parts(.version)[1]), (parts(.version)[2]), .version)
+         | last
+         | .version)
+      end
+  ' "$RECOMMENDATIONS_FILE" 2>/dev/null || true)
+  [[ -n "$rec" ]] && echo "$rec" || echo "$default_ver"
+}
+
+get_max_severity_for_pkg_version() {
+  local pkg="$1"
+  local fixed_ver="$2"
+  awk -F'\t' -v pkg="$pkg" -v fixed_ver="$fixed_ver" '
+    function rank(sev) {
+      if (sev=="CRITICAL") return 5
+      if (sev=="HIGH") return 4
+      if (sev=="MEDIUM") return 3
+      if (sev=="LOW") return 2
+      if (sev=="INFO") return 1
+      return 0
+    }
+    $1==pkg && $3==fixed_ver {
+      r=rank($4)
+      if (r > maxr) {
+        maxr=r
+        maxsev=$4
+      }
+    }
+    END {
+      if (maxsev!="") print maxsev
+      else print "UNKNOWN"
+    }
+  ' "$PARSED_FILE"
+}
+
+upsert_pkg_cve_for_version() {
+  local pkg="$1"
+  local fixed_ver="$2"
+  local cve="$3"
+  local key="${pkg}@${fixed_ver}"
+  local existing
+  existing=$(awk -F'\t' -v key="$key" '$1==key {print $2; exit}' "$CVE_VERSION_MAP_FILE")
+
+  if [[ -z "$existing" ]]; then
+    printf "%s\t%s\n" "$key" "$cve" >> "$CVE_VERSION_MAP_FILE"
+    return
+  fi
+
+  if echo "$existing" | grep -qF "$cve"; then
+    return
+  fi
+
+  awk -F'\t' -v OFS='\t' -v key="$key" -v cve="$cve" '
+    $1==key { $2=$2 ", " cve }
+    { print }
+  ' "$CVE_VERSION_MAP_FILE" > "${CVE_VERSION_MAP_FILE}.tmp" && mv "${CVE_VERSION_MAP_FILE}.tmp" "$CVE_VERSION_MAP_FILE"
+}
+
+upsert_pkg_cve() {
+  local pkg="$1"
+  local cve="$2"
+  local existing
+  existing=$(awk -F'\t' -v pkg="$pkg" '$1==pkg {print $2; exit}' "$CVE_MAP_FILE")
+
+  if [[ -z "$existing" ]]; then
+    printf "%s\t%s\n" "$pkg" "$cve" >> "$CVE_MAP_FILE"
+    return
+  fi
+
+  if echo "$existing" | grep -qF "$cve"; then
+    return
+  fi
+
+  awk -F'\t' -v OFS='\t' -v pkg="$pkg" -v cve="$cve" '
+    $1==pkg { $2=$2 ", " cve }
+    { print }
+  ' "$CVE_MAP_FILE" > "${CVE_MAP_FILE}.tmp" && mv "${CVE_MAP_FILE}.tmp" "$CVE_MAP_FILE"
+}
+
+build_module_cache() {
+  [[ -n "$ALL_MODULES_SORTED" ]] && return
+
+  if command -v go &>/dev/null; then
+    ALL_MODULES_SORTED=$(GOFLAGS='-mod=readonly' go list -m all 2>/dev/null \
+      | awk '{ print length($0) "\t" $0 }' \
+      | sort -rn \
+      | cut -f2- || true)
+  fi
+
+  if [[ -z "$ALL_MODULES_SORTED" ]] && [[ -f go.mod ]]; then
+    ALL_MODULES_SORTED=$(awk '/^[[:space:]]+[[:alnum:]][^[:space:]]*/ { print $1 }' go.mod \
+      | awk '{ print length($0) "\t" $0 }' \
+      | sort -rn \
+      | cut -f2- || true)
+  fi
+}
+
+build_direct_module_cache() {
+  [[ -n "$DIRECT_MODULES" ]] && return
+  if ! command -v go &>/dev/null; then
+    return
+  fi
+
+  DIRECT_MODULES=$(GOFLAGS='-mod=readonly' go list -m -f '{{.Path}} {{if .Indirect}}indirect{{else}}direct{{end}}' all 2>/dev/null \
+    | awk '$2=="direct" { print $1 }' || true)
+
+  if [[ -z "$DIRECT_MODULES" ]] && [[ -f go.mod ]]; then
+    # Fallback: derive direct requirements from go.mod when go list fails.
+    DIRECT_MODULES=$(awk '
+      /^[[:space:]]*require[[:space:]]*\($/ { in_req=1; next }
+      in_req && /^[[:space:]]*\)/ { in_req=0; next }
+      in_req {
+        if ($1 !~ /^\/\//) {
+          line=$0
+          if (line !~ /\/\/[[:space:]]*indirect/) print $1
+        }
+        next
+      }
+      /^[[:space:]]*require[[:space:]]+/ {
+        if ($2 !~ /^\/\//) {
+          line=$0
+          if (line !~ /\/\/[[:space:]]*indirect/) print $2
+        }
+      }
+    ' go.mod | sort -u || true)
+  fi
+}
+
+resolve_module_for_path() {
+  local pkg_path="$1"
+  build_module_cache
+  if [[ -z "$ALL_MODULES_SORTED" ]]; then
+    echo "$pkg_path"
+    return
+  fi
+
+  local mod=""
+  mod=$(printf '%s\n' "$ALL_MODULES_SORTED" | awk -v p="$pkg_path" '
+    p==$0 || index(p, $0"/")==1 { print; exit }
+  ' || true)
+
+  if [[ -n "$mod" ]]; then
+    echo "$mod"
+  else
+    echo "$pkg_path"
+  fi
+}
+
+is_direct_module_dep() {
+  local mod="$1"
+  [[ -z "$mod" ]] && return 1
+  build_direct_module_cache
+  [[ -z "$DIRECT_MODULES" ]] && return 1
+  printf '%s\n' "$DIRECT_MODULES" | grep -Fxq "$mod"
+}
+
+escape_regex() {
+  # Escape regex metacharacters so module paths are matched literally in go.mod.
+  printf '%s' "$1" | sed -e 's/[][(){}.^$*+?|\\/]/\\&/g'
+}
+
+# ====== APPLY PHASE (for apply/full modes) ======
+if [[ "$MODE" =~ ^(apply|full)$ ]]; then
+
+# Pre-compute go mod graph and go mod why results BEFORE any go.mod edits.
+# This is critical: go mod edit (for fixable packages) can modify go.mod/go.sum,
+# causing subsequent go mod why calls to fail with checksum mismatches.
+_WHY_CACHE_DIR=$(mktemp -d)
+trap 'rm -rf "$_WHY_CACHE_DIR"' EXIT
+_PRECOMPUTED_GRAPH_OUT=""
+if command -v go &>/dev/null; then
+  _PRECOMPUTED_GRAPH_OUT=$(GOFLAGS='-mod=readonly' go mod graph 2>/dev/null || true)
+fi
+while IFS=$'\t' read -r _PC_PKG _PC_VER _PC_FIX _PC_SEV _PC_CVE; do
+  [[ -z "$_PC_PKG" ]] && continue
+  [[ "$_PC_FIX" != "NONE" && -n "$_PC_FIX" ]] && continue
+  _PC_MOD=$(resolve_module_for_path "$_PC_PKG")
+  _PC_WHY_FILE="$_WHY_CACHE_DIR/$(printf '%s' "$_PC_PKG" | tr '/' '_' | tr '@' '_')"
+  _PC_WHY=""
+  if command -v go &>/dev/null; then
+    _PC_WHY=$(GOFLAGS='-mod=readonly' go mod why "$_PC_PKG" 2>/dev/null || true)
+    if [[ -z "$_PC_WHY" ]] || echo "$_PC_WHY" | grep -qi "main module does not need package"; then
+      _PC_WHY=$(GOFLAGS='-mod=readonly' go mod why -m "$_PC_MOD" 2>/dev/null || true)
+    fi
+  fi
+  printf '%s\n' "$_PC_WHY" > "$_PC_WHY_FILE"
+done < "$PARSED_FILE"
+
+while IFS=$'\t' read -r PACKAGE CURRENT_VERSION FIXED_VERSION SEVERITY CVE_ID; do
+
+  [[ -z "$PACKAGE" ]] && continue
+
+  # CVE maps are pre-populated from the full parsed file before this loop.
+
+  if [[ "$FIXED_VERSION" == "NONE" || -z "$FIXED_VERSION" ]]; then
+    if printf '%s\n' "$SEEN_NO_FIX_KEYS" | grep -Fxq "${PACKAGE}@NO_FIX"; then
+      continue
+    fi
+    SEEN_NO_FIX_KEYS="${SEEN_NO_FIX_KEYS}"$'\n'"${PACKAGE}@NO_FIX"
+
+    PKG_CVES=$(get_pkg_cves "$PACKAGE")
+    NO_FIX_MSG=""
+    DISPLAY_VERSION="$CURRENT_VERSION"
+    if [[ -n "$DISPLAY_VERSION" && "$DISPLAY_VERSION" != v* ]]; then
+      DISPLAY_VERSION="v${DISPLAY_VERSION}"
+    fi
+    PACKAGE_MODULE=$(resolve_module_for_path "$PACKAGE")
+    # Transitive detection — three tiers, most reliable first:
+    #  1. go.mod contains no direct require for module
+    #  2. go.mod has "// indirect": annotation is authoritative, no go list needed
+    #  3. go list -m all: fallback for edge cases (may be stale mid-run)
+    PACKAGE_MODULE_REGEX=$(escape_regex "$PACKAGE_MODULE")
+    DIRECT_REQUIRE_RE="(^[[:space:]]*${PACKAGE_MODULE_REGEX}[[:space:]]|^[[:space:]]*require[[:space:]]+${PACKAGE_MODULE_REGEX}[[:space:]])"
+    INDIRECT_REQUIRE_RE="(^[[:space:]]*${PACKAGE_MODULE_REGEX}[[:space:]].*//[[:space:]]*indirect|^[[:space:]]*require[[:space:]]+${PACKAGE_MODULE_REGEX}[[:space:]].*//[[:space:]]*indirect)"
+    IS_TRANSITIVE=false
+    if [[ -f go.mod ]]; then
+      if ! grep -Eq "$DIRECT_REQUIRE_RE" go.mod; then
+        IS_TRANSITIVE=true
+      elif grep -Eq "$INDIRECT_REQUIRE_RE" go.mod; then
+        IS_TRANSITIVE=true
+      elif ! is_direct_module_dep "$PACKAGE_MODULE"; then
+        IS_TRANSITIVE=true
+      fi
+    fi
+    if [[ "$IS_TRANSITIVE" == "true" ]]; then
+      IMPORTING_REPOS=""
+      # Use pre-computed graph/why results (collected before any go.mod edits).
+      # Direct go mod graph/why calls here would fail after go mod edit modifies go.sum.
+      if [[ -n "$_PRECOMPUTED_GRAPH_OUT" ]]; then
+        IMPORTING_REPOS=$(printf '%s\n' "$_PRECOMPUTED_GRAPH_OUT" | awk -v mod="$PACKAGE_MODULE" -v current="$CURRENT_MODULE" '
+          {
+            split($1, p, "@")
+            split($2, c, "@")
+            parent_mod = p[1]
+            child_mod = c[1]
+            if (child_mod == mod && parent_mod != "" && parent_mod != current) {
+              repos[parent_mod] = 1
+            }
+          }
+          END {
+            for (repo in repos) {
+              print repo
+            }
+          }
+        ' | sort -u || true)
+      fi
+
+      if [[ -z "$IMPORTING_REPOS" ]]; then
+        # Read pre-computed go mod why output from cache file.
+        _PC_WHY_FILE="$_WHY_CACHE_DIR/$(printf '%s' "$PACKAGE" | tr '/' '_' | tr '@' '_')"
+        WHY_OUT=""
+        [[ -f "$_PC_WHY_FILE" ]] && WHY_OUT=$(cat "$_PC_WHY_FILE")
+        while IFS= read -r pkg_path; do
+          [[ -z "$pkg_path" || "$pkg_path" =~ ^# ]] && continue
+          [[ "$pkg_path" =~ ^\(main[[:space:]]+module[[:space:]]+does[[:space:]]+not[[:space:]]+need ]] && continue
+          [[ "$pkg_path" == "$PACKAGE"* ]] && continue
+          [[ "$pkg_path" == "$PACKAGE_MODULE"* ]] && continue
+          [[ -n "$CURRENT_MODULE" && "$pkg_path" == "$CURRENT_MODULE"* ]] && continue
+          IMPORTER=$(resolve_module_for_path "$pkg_path")
+          [[ -z "$IMPORTER" ]] && continue
+          [[ "$IMPORTER" == "$PACKAGE"* ]] && continue
+          [[ -n "$CURRENT_MODULE" && "$IMPORTER" == "$CURRENT_MODULE"* ]] && continue
+          IMPORTING_REPOS="${IMPORTING_REPOS}"$'\n'"${IMPORTER}"
+        done <<< "$WHY_OUT"
+        IMPORTING_REPOS=$(echo "$IMPORTING_REPOS" | sort -u | grep -v '^$' || true)
+      fi
+      if [[ -n "$IMPORTING_REPOS" ]]; then
+        PARENT_LIST=""
+        while IFS= read -r repo; do
+          [[ -z "$repo" ]] && continue
+          PARENT_LIST="${PARENT_LIST}\n  - ${repo}"
+        done <<< "$IMPORTING_REPOS"
+        NO_FIX_MSG="${PKG_CVES}\n${PACKAGE} ${DISPLAY_VERSION} [${SEVERITY}] - no fix version available, transitive dependency from:${PARENT_LIST}"
+      else
+        NO_FIX_MSG="${PKG_CVES}\n${PACKAGE} ${DISPLAY_VERSION} [${SEVERITY}] - no fix version available, transitive dependency"
+      fi
+    fi
+    if [[ -z "$NO_FIX_MSG" ]]; then
+      NO_FIX_MSG="${PKG_CVES}\n${PACKAGE} ${DISPLAY_VERSION} [${SEVERITY}] - no fix version available yet"
+    fi
+    UNAVAILABLE="${UNAVAILABLE}\n\n${NO_FIX_MSG}"
+    continue
+  fi
+
+  if [[ "$PACKAGE" == "stdlib" ]]; then
+    if [[ -z "$STDLIB_CURRENT_VERSION" ]]; then
+      STDLIB_CURRENT_VERSION="$CURRENT_VERSION"
+    fi
+    if [[ -z "$STDLIB_FIXED_VERSION" ]] || version_lt "$STDLIB_FIXED_VERSION" "$FIXED_VERSION"; then
+      STDLIB_FIXED_VERSION="$FIXED_VERSION"
+      STDLIB_UPDATE_NEEDED="Go ${STDLIB_CURRENT_VERSION} -> ${STDLIB_FIXED_VERSION}"
+    fi
+    continue
+  fi
+
+  # Apply updates for any non-stdlib package reported by Wiz (e.g., gopkg.in/* too).
+  if [[ -n "$PACKAGE" ]]; then
+    REQUIRED_MIN_VERSION=$(get_highest_fixed_version_for_pkg "$PACKAGE")
+    [[ -z "$REQUIRED_MIN_VERSION" ]] && continue
+    HIGHEST_FIXED_VERSION="$REQUIRED_MIN_VERSION"
+
+    # Resolve the recommended version first (risk-scorer picks this version, and the
+    # allowlist is keyed on it — not on the raw highest CVE fix version).
+    RECOMMENDED=$(get_recommended_version "$PACKAGE" "$REQUIRED_MIN_VERSION")
+    if [[ -n "$RECOMMENDED" ]] && ! version_lt "$RECOMMENDED" "$REQUIRED_MIN_VERSION"; then
+      HIGHEST_FIXED_VERSION="$RECOMMENDED"
+    fi
+
+    # Check if this package+version is allowed (for apply mode with allowlist)
+    if ! is_allowed "$PACKAGE" "$HIGHEST_FIXED_VERSION"; then
+      continue
+    fi
+
+      # Use the actual version being applied for accurate CVE/severity metadata
+      APPLIED_VERSION="$HIGHEST_FIXED_VERSION"
+      PKG_CVES=$(get_pkg_cves_for_version "$PACKAGE" "$APPLIED_VERSION")
+      EFFECTIVE_SEVERITY=$(get_max_severity_for_pkg_version "$PACKAGE" "$APPLIED_VERSION")
+      SUMMARY_KEY="${PACKAGE}@${APPLIED_VERSION}"
+
+      # Show every suggested version in summary, but only apply the highest one.
+      if [[ "$FIXED_VERSION" != "$APPLIED_VERSION" ]]; then
+        REPORTED_KEY="${PACKAGE}@${FIXED_VERSION}"
+        if ! printf '%s\n' "$SEEN_SUMMARY_KEYS" | grep -Fxq "$REPORTED_KEY"; then
+          SEEN_SUMMARY_KEYS="${SEEN_SUMMARY_KEYS}"$'\n'"${REPORTED_KEY}"
+          REPORTED_CVES=$(get_pkg_cves_for_version "$PACKAGE" "$FIXED_VERSION")
+          REPORTED_SEV=$(get_max_severity_for_pkg_version "$PACKAGE" "$FIXED_VERSION")
+          FIXED_LIST="${FIXED_LIST}\n${PACKAGE}\tv${CURRENT_VERSION}\tv${FIXED_VERSION} (reported only)\t${REPORTED_SEV}\t${REPORTED_CVES}"
+        fi
+        continue
+      fi
+
+      if printf '%s\n' "$SEEN_APPLIED_KEYS" | grep -Fxq "${PACKAGE}@${HIGHEST_FIXED_VERSION}"; then
+        continue
+      fi
+      SEEN_APPLIED_KEYS="${SEEN_APPLIED_KEYS}"$'\n'"${PACKAGE}@${HIGHEST_FIXED_VERSION}"
+
+      CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | grep -oE '^[0-9]+' | head -1)
+      CURRENT_MINOR=$(echo "$CURRENT_VERSION" | grep -oE '^[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+      FIXED_MAJOR=$(echo "$HIGHEST_FIXED_VERSION" | grep -oE '^[0-9]+' | head -1)
+      FIXED_MINOR=$(echo "$HIGHEST_FIXED_VERSION" | cut -d. -f2)
+      if [[ -n "$CURRENT_MAJOR" && -n "$FIXED_MAJOR" && -n "$CURRENT_MINOR" && -n "$FIXED_MINOR" ]]; then
+        MAJOR_JUMP=$((FIXED_MAJOR - CURRENT_MAJOR))
+        MINOR_JUMP=$((FIXED_MINOR - CURRENT_MINOR))
+        if [[ "$MAJOR_JUMP" -gt 0 || "$MINOR_JUMP" -gt 10 ]]; then
+          if [[ "$MAJOR_JUMP" -gt 0 ]]; then
+            JUMP_DESC="${MAJOR_JUMP} major versions"
+          else
+            JUMP_DESC="${MINOR_JUMP} minor versions"
+          fi
+          MAJOR_JUMPS="${MAJOR_JUMPS}\n\n${PKG_CVES}\n${PACKAGE}: v${CURRENT_VERSION} -> v${HIGHEST_FIXED_VERSION} (${JUMP_DESC})"
+          continue
+        fi
+      fi
+
+      if go mod edit -require "${PACKAGE}@v${HIGHEST_FIXED_VERSION}" 2>/dev/null; then
+        if go mod download "${PACKAGE}@v${HIGHEST_FIXED_VERSION}" >/dev/null 2>&1; then
+          GO_MOD_CHANGED=true
+          if ! printf '%s\n' "$SEEN_SUMMARY_KEYS" | grep -Fxq "$SUMMARY_KEY"; then
+            SEEN_SUMMARY_KEYS="${SEEN_SUMMARY_KEYS}"$'\n'"${SUMMARY_KEY}"
+            FIXED_LIST="${FIXED_LIST}\n${PACKAGE}\tv${CURRENT_VERSION}\tv${HIGHEST_FIXED_VERSION} (applied)\t${EFFECTIVE_SEVERITY}\t${PKG_CVES}"
+          fi
+        else
+          git checkout -- go.mod go.sum 2>/dev/null || true
+          UNAVAILABLE="${UNAVAILABLE}\n- ${PACKAGE} v${HIGHEST_FIXED_VERSION} - download failed"
+        fi
+      else
+        UNAVAILABLE="${UNAVAILABLE}\n- ${PACKAGE} v${HIGHEST_FIXED_VERSION} - could not update"
+      fi
+    fi
+done < "$PARSED_FILE"
+
+fi  # End of apply/full mode
+
+# ====== FINALIZATION (for apply/full modes only) ======
+if [[ "$MODE" =~ ^(apply|full)$ ]]; then
+
+if [[ "$GO_MOD_CHANGED" == "true" ]]; then
+  if go mod tidy >/dev/null 2>&1 && go mod vendor >/dev/null 2>&1; then
+    HAS_FIXES=true
+  else
+    git checkout -- go.mod go.sum vendor/ 2>/dev/null || true
+    GO_MOD_CHANGED=false
+    HAS_FIXES=false
+    # Prevent misleading summary output: updates were attempted but rolled back.
+    FIXED_LIST=""
+    UNAVAILABLE="${UNAVAILABLE}\n- go mod tidy/vendor failed, all dependency changes were reverted"
+  fi
+fi
+
+{
+  echo "## Vulnerability Fix Summary"
+  echo ""
+
+  if [[ -n "$FIXED_LIST" ]]; then
+    echo "### Packages Updated"
+    echo "Note: If multiple fixed versions are suggested for a package, all are shown for visibility, but only one selected version is applied: the recommended version when it meets the required minimum fix floor, otherwise the required minimum version."
+    echo ""
+    echo "| Package | From | To | Severity | CVEs |"
+    echo "|---------|------|----|----------|------|"
+    printf "%b\n" "${FIXED_LIST#\\n}" | awk -F'\t' 'NF>=5 { printf "| %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5 }'
+    echo ""
+  fi
+
+  if [[ -n "$UNAVAILABLE" ]]; then
+    echo "### Vulnerabilities Requiring Manual Remediation"
+    printf "%b\n" "${UNAVAILABLE#\\n}"
+    echo ""
+  fi
+
+  if [[ -n "$MAJOR_JUMPS" ]]; then
+    echo "### Skipped Large Version Jumps"
+    printf "%b\n" "${MAJOR_JUMPS#\\n}"
+    echo ""
+  fi
+
+  if [[ -n "$STDLIB_UPDATE_NEEDED" ]]; then
+    echo "### Go Stdlib Update Required"
+    echo "- ${STDLIB_UPDATE_NEEDED}"
+    echo "- Update builder/toolchain definition in your central build repo."
+    echo ""
+  fi
+} > "$SUMMARY_FILE"
+
+echo "Wrote ${PARSED_FILE} and ${SUMMARY_FILE}"
+
+fi  # End of apply/full mode
+
+# Parse mode exits earlier after writing map artifacts.
+

--- a/.github/skills/go-vuln-remediate/scripts/risk-score.sh
+++ b/.github/skills/go-vuln-remediate/scripts/risk-score.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Compatible with bash and zsh. When invoked via `zsh script.sh`, emulate bash
+# to normalise array indexing, word splitting, and option behaviour.
+[ -n "$ZSH_VERSION" ] && emulate bash
+set -euo pipefail
+
+# Risk scoring with exploit urgency (Jobs #3 + #4)
+# Input: parsed-vulns.txt, version-recommendations.jsonl
+# Output: risk-decisions.jsonl with decision (auto_apply|review_required|skip_auto)
+
+INPUT="parsed-vulns.txt"
+RECOMMENDATIONS="version-recommendations.jsonl"
+OUTPUT="risk-decisions.jsonl"
+MODE="heuristic"
+AUTO_THR="0.50"
+REVIEW_THR="0.70"
+MIN_CONF="0.60"
+CONFIDENCE="0.80"
+EXPLOIT_WEIGHT="0.4"
+VERSION_WEIGHT="0.3"
+CYCLE_WEIGHT="0.3"
+METRICS_FILE="${CI_METRICS_FILE:-ci-metrics.tsv}"
+RECOMMENDATIONS_INDEX=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  risk-score.sh [options]
+Options:
+  --input <file>                  Parsed vulns (default: parsed-vulns.txt)
+  --recommendations <file>        Version recommendations (default: version-recommendations.jsonl)
+  --output <file>                 Output decisions (default: risk-decisions.jsonl)
+  --mode <heuristic>              Scoring mode (default: heuristic)
+  --auto-threshold <float>        Auto-apply threshold (default: 0.50)
+  --review-threshold <float>      Review-required threshold (default: 0.70)
+  --min-confidence <float>        Min confidence for decision (default: 0.60)
+  --confidence <float>            Confidence score (default: 0.80)
+  --exploit-weight <float>        Weight for exploit score (default: 0.4)
+  --version-weight <float>        Weight for version safety (default: 0.3)
+  --cycle-weight <float>          Weight for cycle time (default: 0.3)
+  --metrics-file <file>           Historical CI metrics file (default: CI_METRICS_FILE or ci-metrics.tsv)
+  -h, --help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input) INPUT="${2:-}"; shift 2 ;;
+    --recommendations) RECOMMENDATIONS="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    --mode) MODE="${2:-}"; shift 2 ;;
+    --auto-threshold) AUTO_THR="${2:-}"; shift 2 ;;
+    --review-threshold) REVIEW_THR="${2:-}"; shift 2 ;;
+    --min-confidence) MIN_CONF="${2:-}"; shift 2 ;;
+    --confidence) CONFIDENCE="${2:-}"; shift 2 ;;
+    --exploit-weight) EXPLOIT_WEIGHT="${2:-}"; shift 2 ;;
+    --version-weight) VERSION_WEIGHT="${2:-}"; shift 2 ;;
+    --cycle-weight) CYCLE_WEIGHT="${2:-}"; shift 2 ;;
+    --metrics-file) METRICS_FILE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ "$MODE" != "heuristic" ]]; then
+  echo "Invalid --mode: $MODE (supported: heuristic)" >&2
+  usage
+  exit 2
+fi
+
+[[ -f "$INPUT" ]] || { echo "Missing input: $INPUT" >&2; exit 1; }
+: > "$OUTPUT"
+
+if [[ -f "$RECOMMENDATIONS" ]]; then
+  RECOMMENDATIONS_INDEX=$(mktemp)
+  trap '[[ -n "$RECOMMENDATIONS_INDEX" && -f "$RECOMMENDATIONS_INDEX" ]] && rm -f "$RECOMMENDATIONS_INDEX"' EXIT
+  jq -r 'select(.package != null and .recommended_version != null) | [.package, .recommended_version, (.safety_score // 0.50)] | @tsv' \
+    "$RECOMMENDATIONS" 2>/dev/null > "$RECOMMENDATIONS_INDEX" || true
+fi
+
+rank_sev() {
+  case "$1" in
+    CRITICAL) echo 5 ;;
+    HIGH) echo 4 ;;
+    MEDIUM) echo 3 ;;
+    LOW) echo 2 ;;
+    INFO) echo 1 ;;
+    *) echo 0 ;;
+  esac
+}
+
+# Estimate cycle time from historical data or heuristic
+estimate_cycle_time() {
+  local pkg="$1"
+  local cur_ver="$2"
+  local fix_ver="$3"
+  
+  # Check if we have historical data in the configured metrics file.
+  if [[ -f "$METRICS_FILE" ]]; then
+    local hist
+    hist=$(awk -F'\t' -v p="$pkg" '$1==p {print $4; exit}' "$METRICS_FILE" 2>/dev/null || true)
+    # Validate: must be a positive integer/float; clamp to minimum 1 to prevent division by zero.
+    if [[ -n "$hist" ]] && awk -v v="$hist" 'BEGIN{exit !(v+0 == v && v+0 > 0)}' 2>/dev/null; then
+      awk -v v="$hist" 'BEGIN{printf "%s", (v < 1 ? 1 : v)}' && return
+    fi
+  fi
+  
+  # Fallback heuristic: major/minor bumps are slower than patch bumps.
+  local cur_norm="${cur_ver#v}"
+  local fix_norm="${fix_ver#v}"
+  local cur_major=0 cur_minor=0 fix_major=0 fix_minor=0
+  IFS='.' read -r cur_major cur_minor _ <<< "$cur_norm"
+  IFS='.' read -r fix_major fix_minor _ <<< "$fix_norm"
+  cur_major=${cur_major:-0}
+  cur_minor=${cur_minor:-0}
+  fix_major=${fix_major:-0}
+  fix_minor=${fix_minor:-0}
+
+  if [[ "$fix_major" != "$cur_major" || "$fix_minor" != "$cur_minor" ]]; then
+    echo "7"
+  else
+    echo "1"
+  fi
+}
+
+# Get version safety score from recommendations
+get_version_safety() {
+  local pkg="$1"
+  local fix_ver="$2"
+
+  [[ -n "$RECOMMENDATIONS_INDEX" && -s "$RECOMMENDATIONS_INDEX" ]] || { echo "0.50"; return; }
+
+  local score
+  score=$(awk -F'\t' -v p="$pkg" -v v="$fix_ver" '$1==p && $2==v {print $3; exit}' "$RECOMMENDATIONS_INDEX" 2>/dev/null || true)
+  [[ -z "$score" ]] && score="0.50"
+  echo "$score"
+}
+
+# Aggregate by package + fixed_version and score each
+awk -F'\t' '
+  $1!="" && $3!="" && $3!="NONE" {
+    key=$1 "\t" $2 "\t" $3
+    sev_rank=($4=="CRITICAL"?5:($4=="HIGH"?4:($4=="MEDIUM"?3:($4=="LOW"?2:($4=="INFO"?1:0)))))
+    if (sev_rank > max_sev[key]) { 
+      max_sev[key]=sev_rank
+      max_sev_txt[key]=$4 
+    }
+    if ($5 != "") {
+      cve_key=key SUBSEP $5
+      if (!seen_cve[cve_key]++) {
+        cve_count[key]++
+      }
+    }
+  }
+  END {
+    for (k in max_sev) {
+      split(k, a, "\t")
+      pkg=a[1]; cur=a[2]; fix=a[3]
+      c=(k in cve_count ? cve_count[k] : 0)
+      print pkg "\t" cur "\t" fix "\t" max_sev_txt[k] "\t" c
+    }
+  }
+' "$INPUT" | sort -u | while IFS=$'\t' read -r pkg cur fix sev cvecount; do
+  
+  # Exploit score (based on severity + exploitability)
+  sev_rank=$(rank_sev "$sev")
+  exploit_score=$(awk -v s="$sev_rank" 'BEGIN{printf "%.2f", s/5.0}')
+  
+  # Version safety score from recommendations
+  version_safety=$(get_version_safety "$pkg" "$fix")
+  
+  # Cycle time and urgency
+  cycle_time=$(estimate_cycle_time "$pkg" "$cur" "$fix")
+  urgency_score=$(awk -v e="$exploit_score" -v c="$cycle_time" 'BEGIN{printf "%.2f", e/c}')
+  
+  # Combined risk score: weighted average
+  # version_safety is a safety signal (high = safe), so invert it to a risk term.
+  risk_score=$(awk \
+    -v exploit="$exploit_score" \
+    -v version="$version_safety" \
+    -v urgency="$urgency_score" \
+    -v ew="$EXPLOIT_WEIGHT" \
+    -v vw="$VERSION_WEIGHT" \
+    -v cw="$CYCLE_WEIGHT" \
+    'BEGIN{
+      combined=(exploit*ew + (1-version)*vw + urgency*cw)/(ew+vw+cw)
+      if(combined<0) combined=0
+      if(combined>1) combined=1
+      printf "%.2f", combined
+    }')
+  
+  confidence="$CONFIDENCE"
+  decision="skip_auto"
+  reasons=()
+  
+  # Decision logic and urgency evaluation in one awk call.
+  decision_eval=$(awk -v s="$risk_score" -v a="$AUTO_THR" -v r="$REVIEW_THR" -v c="$confidence" -v m="$MIN_CONF" -v u="$urgency_score" '
+    BEGIN {
+      d="skip_auto"
+      reason="risk_score>=review_threshold"
+      if (s < a && c >= m) {
+        d="auto_apply"
+        reason="risk_score<auto_threshold"
+      } else if (s < r) {
+        d="review_required"
+        reason="risk_score<review_threshold"
+      }
+      hu=(u>=0.50)?1:0
+      printf "%s\t%s\t%d", d, reason, hu
+    }
+  ')
+  IFS=$'\t' read -r decision primary_reason high_urgency_flag <<< "$decision_eval"
+  reasons+=("$primary_reason")
+  
+  # Add context reasons
+  [[ "$sev" == "CRITICAL" ]] && reasons+=("severity=CRITICAL")
+  if [[ "$cvecount" -ge 3 ]]; then
+    reasons+=("cve_count>=3")
+    reasons+=("cve_count=${cvecount}")
+  fi
+  [[ "${high_urgency_flag:-0}" -eq 1 ]] && reasons+=("high_urgency")
+  
+  reasons_json=$(printf "%s\n" "${reasons[@]}" | awk 'NF{printf "\"%s\",",$0}' | sed 's/,$//')
+  [[ -z "$reasons_json" ]] && reasons_json="\"baseline\""
+  
+  printf '{"package":"%s","current_version":"%s","fixed_version":"%s","severity_max":"%s","cve_count":%s,"exploit_score":%s,"version_safety":%s,"urgency_score":%s,"risk_score":%s,"confidence":%s,"cycle_time_days":%s,"decision":"%s","reasons":[%s]}\n' \
+    "$pkg" "$cur" "$fix" "$sev" "${cvecount:-0}" "$exploit_score" "$version_safety" "$urgency_score" "$risk_score" "$confidence" "$cycle_time" "$decision" "$reasons_json" >> "$OUTPUT"
+done
+
+echo "Wrote $OUTPUT"

--- a/.github/skills/go-vuln-remediate/scripts/version-selector.sh
+++ b/.github/skills/go-vuln-remediate/scripts/version-selector.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Compatible with bash and zsh. When invoked via `zsh script.sh`, emulate bash
+# to normalise array indexing, word splitting, and option behaviour.
+[ -n "$ZSH_VERSION" ] && emulate bash
+set -euo pipefail
+
+# Recommend safest-scored fix version among candidates (Job #3)
+# Input: parsed-vulns.txt (pkg, cur_ver, fix_ver, sev, cve)
+# Output: version-recommendations.jsonl (JSONL; one row per package+candidate fix version)
+# Fields: package, current_version, recommended_version, safety_score, reasons[]
+
+INPUT="${1:-parsed-vulns.txt}"
+OUTPUT="${2:-version-recommendations.jsonl}"
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "Input file not found: $INPUT" >&2
+  exit 1
+fi
+
+: > "$OUTPUT"
+
+# Aggregate by package to find all candidate fix versions
+awk -F'\t' '$3!="NONE" && $3!="" {
+  pkg=$1
+  cur=$2
+  fix=$3
+  key=pkg "\t" fix
+  candidates[key]=1
+  current_ver[pkg]=cur
+}
+END {
+  for (k in candidates) {
+    split(k, a, "\t")
+    print a[1] "\t" a[2]
+  }
+}' "$INPUT" | sort -u | while IFS=$'\t' read -r pkg fix_ver; do
+  
+  cur_ver=$(awk -F'\t' -v p="$pkg" '$1==p {print $2; exit}' "$INPUT")
+  
+  # Parse versions: v1.2.3 -> major.minor.patch
+  cur_norm="${cur_ver#v}"
+  fix_norm="${fix_ver#v}"
+  cur_major=0
+  cur_minor=0
+  cur_patch=0
+  fix_major=0
+  fix_minor=0
+  fix_patch=0
+  IFS='.' read -r cur_major cur_minor cur_patch <<< "$cur_norm"
+  IFS='.' read -r fix_major fix_minor fix_patch <<< "$fix_norm"
+  cur_major=${cur_major:-0}
+  cur_minor=${cur_minor:-0}
+  cur_patch=${cur_patch:-0}
+  fix_major=${fix_major:-0}
+  fix_minor=${fix_minor:-0}
+  fix_patch=${fix_patch:-0}
+  
+  safety_score="1.00"
+  reasons=()
+  
+  # Major version bump (high risk)
+  if [[ "$fix_major" != "$cur_major" ]]; then
+    safety_score=$(awk 'BEGIN{printf "%.2f", 0.60}')
+    reasons+=("major_version_change")
+  # Minor version bump (medium risk)
+  elif [[ "$fix_minor" != "$cur_minor" ]]; then
+    safety_score=$(awk 'BEGIN{printf "%.2f", 0.85}')
+    reasons+=("minor_version_change")
+  # Patch-only (low risk)
+  else
+    safety_score=$(awk 'BEGIN{printf "%.2f", 0.95}')
+    reasons+=("patch_only")
+  fi
+  
+  # Build reasons JSON array
+  reasons_json=$(printf "%s\n" "${reasons[@]}" | awk 'NF{printf "\"%s\",",$0}' | sed 's/,$//')
+  [[ -z "$reasons_json" ]] && reasons_json="\"baseline\""
+  
+  printf '{"package":"%s","current_version":"%s","recommended_version":"%s","safety_score":%s,"reasons":[%s]}\n' \
+    "$pkg" "$cur_ver" "$fix_ver" "$safety_score" "$reasons_json" >> "$OUTPUT"
+done
+
+echo "Wrote $OUTPUT"

--- a/.github/skills/go-vuln-remediate/scripts/wiz-json-parse.sh
+++ b/.github/skills/go-vuln-remediate/scripts/wiz-json-parse.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Compatible with bash and zsh.
+[ -n "$ZSH_VERSION" ] && emulate bash
+set -euo pipefail
+
+# Wiz JSON parser — converts Wiz JSON scan output to parsed-vulns format.
+# Produces the same tab-delimited output as parse-fix.sh parse mode so that
+# version-selector.sh, risk-score.sh, and parse-fix.sh apply mode work unchanged.
+#
+# Accepts one or more Wiz JSON files; findings from all files are unioned and
+# de-duplicated, so multiple scanned images can be remediated together.
+#
+# Usage:
+#   ./wiz-json-parse.sh <wiz-json-file> [<wiz-json-file> ...] [options]
+#
+# Options:
+#   --parsed FILE          Output file for parsed vulns  (default: parsed-vulns.txt)
+#   --cve-map FILE         Output file for CVE map       (default: cve-map.txt)
+#   --cve-version-map FILE Output file for CVE-per-version map (default: cve-version-map.txt)
+#
+# Output format (matches parse-fix.sh):
+#   parsed-vulns.txt     — PACKAGE\tVERSION\tFIX_VERSION\tSEVERITY\tCVE_ID
+
+PARSED_FILE="parsed-vulns.txt"
+CVE_MAP_FILE="cve-map.txt"
+CVE_VERSION_MAP_FILE="cve-version-map.txt"
+INPUT_FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parsed)          PARSED_FILE="${2:-}";          shift 2 ;;
+    --cve-map)         CVE_MAP_FILE="${2:-}";          shift 2 ;;
+    --cve-version-map) CVE_VERSION_MAP_FILE="${2:-}";  shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 <wiz-json-file> [<wiz-json-file> ...] [options]"
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      INPUT_FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#INPUT_FILES[@]} -eq 0 ]]; then
+  echo "Usage: $0 <wiz-json-file> [<wiz-json-file> ...] [options]" >&2
+  exit 1
+fi
+
+for f in "${INPUT_FILES[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "Input file not found: $f" >&2
+    exit 1
+  fi
+done
+
+: > "$PARSED_FILE"
+: > "$CVE_MAP_FILE"
+: > "$CVE_VERSION_MAP_FILE"
+
+# ── parsed-vulns.txt ─────────────────────────────────────────────────────────
+# Format: PACKAGE\tVERSION\tFIX_VERSION\tSEVERITY\tCVE_ID
+# Extract findings from both Libraries and endOfLifeTechnologies arrays.
+
+jq -r '
+  [
+    (
+      .result.libraries[]?
+      | select(.vulnerabilities != null and (.vulnerabilities | length) > 0)
+      | .name as $pkg
+      | .version as $ver
+      | .vulnerabilities[]?
+      | select(.severity != null and .severity != "")
+      | {
+          package: $pkg,
+          version: ($ver | ltrimstr("v")),
+          fixed: (if (.fixedVersion != null and .fixedVersion != "") then (.fixedVersion | ltrimstr("v")) else "NONE" end),
+          severity: (.severity | ascii_upcase),
+          cve: (.name // "UNKNOWN")
+        }
+    ),
+    (
+      .result.endOfLifeTechnologies[]?
+      | select(.vulnerabilities != null and (.vulnerabilities | length) > 0)
+      | .name as $pkg
+      | .version as $ver
+      | .vulnerabilities[]?
+      | select(.severity != null and .severity != "")
+      | {
+          package: $pkg,
+          version: ($ver | ltrimstr("v")),
+          fixed: "NONE",
+          severity: (.severity | ascii_upcase),
+          cve: (.name // "EOL-TECHNOLOGY")
+        }
+    )
+  ]
+  | .[]
+  | [.package, .version, .fixed, .severity, .cve]
+  | @tsv
+' "${INPUT_FILES[@]}" | sort -u > "$PARSED_FILE"
+
+TOTAL=$(wc -l < "$PARSED_FILE" | tr -d ' ')
+echo "Parsed $TOTAL vulnerability records from Wiz JSON into $PARSED_FILE"
+
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "No vulnerabilities found in ${INPUT_FILES[*]}"
+  exit 0
+fi
+
+# ── cve-map.txt ───────────────────────────────────────────────────────────────
+# Format: PACKAGE\tCVE1, CVE2, ...
+awk -F'\t' '
+  NF >= 5 && $1 != "" && $5 != "" && !seen[$1 SUBSEP $5]++ {
+    if (list[$1] != "") list[$1] = list[$1] ", " $5
+    else list[$1] = $5
+  }
+  END {
+    for (pkg in list) print pkg "\t" list[pkg]
+  }
+' "$PARSED_FILE" | sort > "$CVE_MAP_FILE"
+
+# ── cve-version-map.txt ───────────────────────────────────────────────────────
+# Format: PACKAGE@FIXVERSION\tCVE1, CVE2, ...  (fixable entries only)
+awk -F'\t' '
+  NF >= 5 && $3 != "" && $3 != "NONE" {
+    key = $1 "@" $3
+    cve = $5
+    if (key != "" && cve != "" && !seen[key SUBSEP cve]++) {
+      if (list[key] != "") list[key] = list[key] ", " cve
+      else list[key] = cve
+    }
+  }
+  END {
+    for (key in list) print key "\t" list[key]
+  }
+' "$PARSED_FILE" | sort > "$CVE_VERSION_MAP_FILE"
+
+echo "CVE maps written: $CVE_MAP_FILE, $CVE_VERSION_MAP_FILE"

--- a/.github/workflows/auto-vuln-fix.yml
+++ b/.github/workflows/auto-vuln-fix.yml
@@ -1,0 +1,564 @@
+name: Vulnerability Scan and Auto-Fix
+
+on:
+  schedule:
+    - cron: "00 01 * * *" # Run daily at 1:00 AM UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: auto-vuln-fix-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  SERVICE_CONFIG_PATH: .github/skills/go-vuln-remediate/konk/service-config.env
+
+jobs:
+  resolve-config:
+    runs-on: ubuntu-latest
+    outputs:
+      target_branch: ${{ steps.config.outputs.target_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ vars.TARGET_BRANCH || 'main' }}
+          fetch-depth: 1
+
+      - name: Resolve target branch from service config
+        id: config
+        run: |
+          load_env_file_strict() {
+            local file="$1"
+            local raw line key value
+            while IFS= read -r raw || [[ -n "$raw" ]]; do
+              line="$raw"
+              line="${line#"${line%%[![:space:]]*}"}"
+              line="${line%"${line##*[![:space:]]}"}"
+              [[ -z "$line" || "$line" == \#* ]] && continue
+
+              if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+                echo "Invalid config line in $file: $raw" >&2
+                exit 1
+              fi
+
+              key="${line%%=*}"
+              value="${line#*=}"
+              value="${value#"${value%%[![:space:]]*}"}"
+              value="${value%"${value##*[![:space:]]}"}"
+
+              if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+                value="${value:1:${#value}-2}"
+              elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+                value="${value:1:${#value}-2}"
+              fi
+
+              export "$key=$value"
+            done < "$file"
+          }
+
+          CONFIG_PATH="${{ env.SERVICE_CONFIG_PATH }}"
+          TARGET_BRANCH="${{ vars.TARGET_BRANCH || 'main' }}"
+          if [[ -f "$CONFIG_PATH" ]]; then
+            load_env_file_strict "$CONFIG_PATH"
+            TARGET_BRANCH="${TARGET_BRANCH:-${{ vars.TARGET_BRANCH || 'main' }}}"
+          fi
+          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+
+  scan-and-remediate:
+    needs: resolve-config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-config.outputs.target_branch }}
+          fetch-depth: 0
+
+      - name: Load service config
+        id: load_config
+        run: |
+          load_env_file_strict() {
+            local file="$1"
+            local raw line key value
+            while IFS= read -r raw || [[ -n "$raw" ]]; do
+              line="$raw"
+              line="${line#"${line%%[![:space:]]*}"}"
+              line="${line%"${line##*[![:space:]]}"}"
+              [[ -z "$line" || "$line" == \#* ]] && continue
+
+              if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+                echo "Invalid config line in $file: $raw" >&2
+                exit 1
+              fi
+
+              key="${line%%=*}"
+              value="${line#*=}"
+              value="${value#"${value%%[![:space:]]*}"}"
+              value="${value%"${value##*[![:space:]]}"}"
+
+              if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+                value="${value:1:${#value}-2}"
+              elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+                value="${value:1:${#value}-2}"
+              fi
+
+              export "$key=$value"
+            done < "$file"
+          }
+
+          CONFIG_PATH="${{ env.SERVICE_CONFIG_PATH }}"
+          if [[ -f "$CONFIG_PATH" ]]; then
+            load_env_file_strict "$CONFIG_PATH"
+          fi
+
+          {
+            echo "IMAGE_NAME=${IMAGE_NAME:-konk-service}"
+            echo "DOCKERFILE_PATH=${DOCKERFILE_PATH:-Dockerfile.konk-service}"
+            echo "SERVER_BUILD_PATH=${SERVER_BUILD_PATH:-.}"
+            echo "SCAN_TARGETS=${SCAN_TARGETS:-konk-service|Dockerfile.konk-service|.|konk-service|cmd/konk-service;konk-provision|Dockerfile.provision|.|konk-provision|cmd/provision}"
+            echo "BUILD_TAGS=${BUILD_TAGS:-}"
+            echo "BUILD_LDFLAGS=${BUILD_LDFLAGS:--s -w}"
+            echo "DOCKER_BUILD_EXTRA_ARGS=${DOCKER_BUILD_EXTRA_ARGS:-}"
+            echo "HARBOR_REGISTRY=${HARBOR_REGISTRY:-}"
+            echo "BASE_IMAGE=${BASE_IMAGE:-gcr.io/distroless/static-debian12:nonroot}"
+            echo "GO_PRIVATE=${GO_PRIVATE:-github.com/${{ github.repository_owner }}/*}"
+            echo "WIZ_CLI_VERSION=${WIZ_CLI_VERSION:-latest}"
+            echo "MODE=${MODE:-heuristic}"
+            echo "RISK_THRESHOLD_AUTO=${RISK_THRESHOLD_AUTO:-0.85}"
+            echo "RISK_THRESHOLD_REVIEW=${RISK_THRESHOLD_REVIEW:-0.90}"
+            echo "MIN_CONFIDENCE=${MIN_CONFIDENCE:-0.70}"
+            echo "CONFIDENCE=${CONFIDENCE:-0.75}"
+            echo "EXPLOIT_WEIGHT=${EXPLOIT_WEIGHT:-0.40}"
+            echo "VERSION_WEIGHT=${VERSION_WEIGHT:-0.35}"
+            echo "CYCLE_WEIGHT=${CYCLE_WEIGHT:-0.25}"
+            echo "CI_METRICS_FILE=${CI_METRICS_FILE:-ci-metrics.tsv}"
+          } >> "$GITHUB_ENV"
+
+          echo "artifact_retention_days=${ARTIFACT_RETENTION_DAYS:-30}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git auth for private modules
+        run: |
+          if [[ -n "${{ secrets.GITPAT }}" ]]; then
+            git config --global url."https://${{ secrets.GITPAT }}@github.com/".insteadOf "https://github.com/"
+          else
+            echo "Skipping private module git auth; GITPAT not configured"
+          fi
+
+      - name: Configure Go module access
+        run: |
+          if [[ -n "$GO_PRIVATE" ]]; then
+            echo "GOPRIVATE=$GO_PRIVATE" >> "$GITHUB_ENV"
+            echo "GONOSUMDB=$GO_PRIVATE" >> "$GITHUB_ENV"
+          fi
+          echo "GOPROXY=https://proxy.golang.org,direct" >> "$GITHUB_ENV"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # konk has no root go.mod; use one of the per-command modules for version detection.
+          go-version-file: cmd/konk-service/go.mod
+          cache: true
+          cache-dependency-path: |
+            cmd/konk-service/go.sum
+            cmd/provision/go.sum
+
+      - name: Check Wiz credentials
+        id: wiz_guard
+        run: |
+          if [[ -n "${{ secrets.WIZ_CLIENT_ID }}" && -n "${{ secrets.WIZ_CLIENT_SECRET }}" ]]; then
+            echo "wiz_ready=true" >> "$GITHUB_OUTPUT"
+            echo "reason=" >> "$GITHUB_OUTPUT"
+          else
+            echo "wiz_ready=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Missing WIZ_CLIENT_ID/WIZ_CLIENT_SECRET; skipping Wiz auth and scan." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report skipped Wiz scan
+        if: steps.wiz_guard.outputs.wiz_ready != 'true'
+        run: |
+          MSG="${{ steps.wiz_guard.outputs.reason }}"
+          {
+            echo "## Auto Vulnerability Fix Result"
+            echo ""
+            echo "$MSG"
+            echo ""
+            echo "No scan/remediation steps were executed in this run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Login to Harbor registry
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          if [[ -z "$HARBOR_REGISTRY" && -z "${{ secrets.HARBOR_SERVICES_PROD_USERNAME }}" && -z "${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}" ]]; then
+            echo "Skipping Harbor login; registry and credentials not configured"
+          elif [[ -n "$HARBOR_REGISTRY" && -n "${{ secrets.HARBOR_SERVICES_PROD_USERNAME }}" && -n "${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}" ]]; then
+            echo "${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}" | docker login "$HARBOR_REGISTRY" -u "${{ secrets.HARBOR_SERVICES_PROD_USERNAME }}" --password-stdin
+          else
+            echo "Harbor login configuration is incomplete. Set HARBOR_REGISTRY, HARBOR_SERVICES_PROD_USERNAME, and HARBOR_SERVICES_PROD_PASSWORD together."
+            exit 1
+          fi
+
+      - name: Build Docker images for scanning
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          EXTRA_ARGS=()
+          if [[ -n "${DOCKER_BUILD_EXTRA_ARGS:-}" ]]; then
+            read -r -a EXTRA_ARGS <<< "$DOCKER_BUILD_EXTRA_ARGS"
+          fi
+
+          IFS=';' read -r -a TARGETS <<< "$SCAN_TARGETS"
+          for entry in "${TARGETS[@]}"; do
+            [[ -z "$entry" ]] && continue
+            IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+            if [[ -z "$t_name" || -z "$t_dockerfile" || -z "$t_image" || -z "$t_module" ]]; then
+              echo "Invalid SCAN_TARGETS entry: '$entry' (expected name|dockerfile|build_path|image_tag|module_dir)" >&2
+              exit 1
+            fi
+            echo "Building $t_image:scan from $t_dockerfile (target: $t_name, module: $t_module)"
+            docker build \
+              -f "$t_dockerfile" \
+              --build-arg BASE_IMAGE="$BASE_IMAGE" \
+              "${EXTRA_ARGS[@]}" \
+              -t "$t_image:scan" .
+          done
+
+      - name: Install Wiz CLI
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          curl -sL --fail -o wizcli "https://downloads.wiz.io/v1/wizcli/${WIZ_CLI_VERSION}/wizcli-linux-amd64"
+          chmod +x wizcli
+          sudo mv wizcli /usr/local/bin/wizcli
+          wizcli version
+
+      - name: Authenticate Wiz
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
+
+      - name: Run Wiz scan
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          set -o pipefail
+          IFS=';' read -r -a TARGETS <<< "$SCAN_TARGETS"
+          for entry in "${TARGETS[@]}"; do
+            [[ -z "$entry" ]] && continue
+            IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+            echo "Scanning $t_image:scan (target: $t_name)"
+            wizcli docker scan -i "$t_image:scan" \
+              -p "PSE: Vulnerability - Critical - Audit/Warn - All Projects" \
+              -p "PSE: Vulnerability - High - Audit/Warn - All Projects" \
+              --json-output-file "wiz-scan-results-${t_name}.json" \
+              --file-hashes-scan \
+              2>&1 | tee "wiz-scan-raw-${t_name}.txt"
+            SCAN_EXIT=${PIPESTATUS[0]}
+            if [ "$SCAN_EXIT" -ne 0 ]; then
+              echo "Wiz scan failed for $t_name with exit code $SCAN_EXIT"
+              exit "$SCAN_EXIT"
+            fi
+            if [ ! -s "wiz-scan-results-${t_name}.json" ]; then
+              echo "Wiz scan produced empty JSON output for $t_name"
+              exit 1
+            fi
+          done
+
+      - name: Parse Wiz JSON vulnerabilities
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          chmod +x .github/skills/go-vuln-remediate/scripts/wiz-json-parse.sh
+          shopt -s nullglob
+          JSON_FILES=(wiz-scan-results-*.json)
+          if [[ ${#JSON_FILES[@]} -eq 0 ]]; then
+            echo "No Wiz scan result files found to parse" >&2
+            exit 1
+          fi
+          echo "Merging findings from: ${JSON_FILES[*]}"
+          .github/skills/go-vuln-remediate/scripts/wiz-json-parse.sh \
+            "${JSON_FILES[@]}" \
+            --parsed parsed-vulns.txt \
+            --cve-map cve-map.txt \
+            --cve-version-map cve-version-map.txt
+
+      - name: Recommend safest fix versions (#3)
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          chmod +x .github/skills/go-vuln-remediate/scripts/version-selector.sh
+          .github/skills/go-vuln-remediate/scripts/version-selector.sh \
+            parsed-vulns.txt \
+            version-recommendations.jsonl
+
+      - name: Risk scoring with exploit urgency (#4)
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          chmod +x .github/skills/go-vuln-remediate/scripts/risk-score.sh
+          .github/skills/go-vuln-remediate/scripts/risk-score.sh \
+            --input parsed-vulns.txt \
+            --recommendations version-recommendations.jsonl \
+            --output risk-decisions.jsonl \
+            --mode "${MODE:-heuristic}" \
+            --auto-threshold "${RISK_THRESHOLD_AUTO:-0.85}" \
+            --review-threshold "${RISK_THRESHOLD_REVIEW:-0.90}" \
+            --min-confidence "${MIN_CONFIDENCE:-0.70}" \
+            --confidence "${CONFIDENCE:-0.75}" \
+            --exploit-weight "${EXPLOIT_WEIGHT:-0.40}" \
+            --version-weight "${VERSION_WEIGHT:-0.35}" \
+            --cycle-weight "${CYCLE_WEIGHT:-0.25}" \
+            --metrics-file "${CI_METRICS_FILE:-ci-metrics.tsv}"
+
+      - name: Build review queue section
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          : > review-queue.md
+          if [[ ! -s risk-decisions.jsonl ]]; then
+            echo "No risk-decisions.jsonl file; skipping review queue section"
+            exit 0
+          fi
+
+          total=$(jq -s '[.[] | select(.decision=="review_required" or .decision=="skip_auto")] | length' risk-decisions.jsonl)
+          if [[ "${total:-0}" -eq 0 ]]; then
+            echo "No review_required or skip_auto items; skipping review queue section"
+            exit 0
+          fi
+
+          rows=$(jq -r '
+            select(.decision=="review_required" or .decision=="skip_auto")
+            | "| "
+              + (.package|tostring|gsub("\\|";"\\\\|"))
+              + " | "
+              + ((.current_version + " -> " + .fixed_version)|tostring|gsub("\\|";"\\\\|"))
+              + " | "
+              + (.decision|tostring)
+              + " | "
+              + (.risk_score|tostring)
+              + " | "
+              + (.confidence|tostring)
+              + " | "
+              + (((.reasons // [])[:2] | join("; "))|tostring|gsub("\\|";"\\\\|"))
+              + " |"
+          ' risk-decisions.jsonl | head -n 20)
+
+          {
+            echo "### Risk Review Queue"
+            echo ""
+            echo "| Package | Version Change | Decision | Risk | Confidence | Reasons |"
+            echo "|---|---|---|---:|---:|---|"
+            echo "$rows"
+            if [[ "$total" -gt 20 ]]; then
+              echo ""
+              echo "_Showing first 20 of $total items. See workflow artifact risk-decisions.jsonl for full list._"
+            fi
+          } > review-queue.md
+
+      - name: Build allowlist from decisions
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          jq -r 'select(.decision=="auto_apply") | "\(.package)\t\(.fixed_version)"' \
+            risk-decisions.jsonl > allowlist.txt || true
+          echo "Allowlist entries: $(wc -l < allowlist.txt)"
+
+      - name: Apply Risk-approved fixes (per module)
+        if: steps.wiz_guard.outputs.wiz_ready == 'true'
+        run: |
+          chmod +x .github/skills/go-vuln-remediate/scripts/parse-fix.sh
+          WORK="$PWD"
+          IFS=';' read -r -a TARGETS <<< "$SCAN_TARGETS"
+          for entry in "${TARGETS[@]}"; do
+            [[ -z "$entry" ]] && continue
+            IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+            if [[ ! -d "$t_module" ]]; then
+              echo "Module dir '$t_module' for target '$t_name' does not exist; skipping" >&2
+              continue
+            fi
+            echo "Applying fixes for target '$t_name' in module '$t_module'"
+            ( cd "$t_module" && "${WORK}/.github/skills/go-vuln-remediate/scripts/parse-fix.sh" \
+                --mode apply \
+                --parsed "${WORK}/parsed-vulns.txt" \
+                --recommendations "${WORK}/version-recommendations.jsonl" \
+                --allowlist "${WORK}/allowlist.txt" \
+                --summary "${WORK}/vuln-fix-summary-${t_name}.md" )
+          done
+
+          # Combine per-module summaries into a single vuln-fix-summary.md
+          {
+            echo "## Automated Vulnerability Fix Summary"
+            echo ""
+            for entry in "${TARGETS[@]}"; do
+              [[ -z "$entry" ]] && continue
+              IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+              summary_file="vuln-fix-summary-${t_name}.md"
+              echo "### Module: ${t_module} (${t_name})"
+              echo ""
+              if [[ -s "$summary_file" ]]; then
+                cat "$summary_file"
+              else
+                echo "_No summary produced for this module._"
+              fi
+              echo ""
+            done
+          } > vuln-fix-summary.md
+
+      - name: Detect dependency changes
+        id: diff
+        run: |
+          IFS=';' read -r -a TARGETS <<< "$SCAN_TARGETS"
+          PATHS=()
+          for entry in "${TARGETS[@]}"; do
+            [[ -z "$entry" ]] && continue
+            IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+            PATHS+=("$t_module/go.mod" "$t_module/go.sum")
+          done
+          # Untracked go.sum files (newly created by go mod tidy) also count as changes.
+          NEW_FILES=$(git ls-files --others --exclude-standard -- "${PATHS[@]}" 2>/dev/null || true)
+          if git diff --quiet -- "${PATHS[@]}" && [[ -z "$NEW_FILES" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write no auto-fix summary
+        if: steps.wiz_guard.outputs.wiz_ready == 'true' && steps.diff.outputs.changed == 'false'
+        run: |
+          STATUS_MSG="No vulnerabilities found by Wiz scan."
+          if [ -s parsed-vulns.txt ]; then
+            STATUS_MSG="Vulnerabilities were detected, but no safe automatic dependency updates were applied."
+          fi
+          {
+            echo "## Auto Vulnerability Fix Result"
+            echo ""
+            echo "$STATUS_MSG"
+            echo ""
+            echo "No changes were made to any module's go.mod/go.sum."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify build after fixes
+        if: steps.diff.outputs.changed == 'true'
+        id: build_check
+        run: |
+          mkdir -p bin
+          WORK="$PWD"
+          BUILD_OK=true
+          IFS=';' read -r -a TARGETS <<< "$SCAN_TARGETS"
+          for entry in "${TARGETS[@]}"; do
+            [[ -z "$entry" ]] && continue
+            IFS='|' read -r t_name t_dockerfile t_buildpath t_image t_module <<< "$entry"
+            echo "Verifying build for target $t_name (module: $t_module, build_path: $t_buildpath)"
+            if ! ( cd "$t_module" && CGO_ENABLED=0 go build -v \
+              -tags "$BUILD_TAGS" \
+              -trimpath \
+              -ldflags "$BUILD_LDFLAGS" \
+              -o "${WORK}/bin/${t_name}" "$t_buildpath" ) 2>&1; then
+              echo "Build failed for target $t_name"
+              BUILD_OK=false
+            fi
+          done
+          if [[ "$BUILD_OK" == "true" ]]; then
+            echo "status=passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+
+      - name: Debug artifact files before upload
+        if: always()
+        run: |
+          echo "## Artifact File Check" >> "$GITHUB_STEP_SUMMARY"
+          shopt -s nullglob
+          for f in \
+            wiz-scan-results-*.json \
+            wiz-scan-raw-*.txt \
+            parsed-vulns.txt \
+            version-recommendations.jsonl \
+            risk-decisions.jsonl \
+            allowlist.txt \
+            cve-map.txt \
+            cve-version-map.txt \
+            vuln-fix-summary.md \
+            vuln-fix-summary-*.md; do
+            if [[ -f "$f" ]]; then
+              bytes=$(wc -c < "$f")
+              lines=$(wc -l < "$f")
+              echo "FOUND  $f (bytes=$bytes, lines=$lines)"
+              echo "- FOUND: $f (bytes=$bytes, lines=$lines)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "MISSING $f"
+              echo "- MISSING: $f" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+      - name: Upload scan and decision artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: auto-vuln-fix-scan-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            wiz-scan-results-*.json
+            wiz-scan-raw-*.txt
+            parsed-vulns.txt
+            version-recommendations.jsonl
+            risk-decisions.jsonl
+            allowlist.txt
+            cve-map.txt
+            cve-version-map.txt
+            vuln-fix-summary.md
+            vuln-fix-summary-*.md
+          retention-days: ${{ steps.load_config.outputs.artifact_retention_days }}
+
+      - name: Create PR body file
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          BUILD_STATUS="${{ steps.build_check.outputs.status }}"
+          RUN_TRIGGER="${{ github.event_name }}"
+          if [[ "$BUILD_STATUS" == "passed" ]]; then
+            BUILD_BADGE="✅ Build passed"
+          else
+            BUILD_BADGE="❌ Build failed — review fixes before merging"
+          fi
+          if [[ "$RUN_TRIGGER" == "schedule" ]]; then
+            RUN_SOURCE="scheduled"
+          elif [[ "$RUN_TRIGGER" == "workflow_dispatch" ]]; then
+            RUN_SOURCE="manual"
+          else
+            RUN_SOURCE="$RUN_TRIGGER"
+          fi
+          {
+            echo "## Automated Vulnerability Fix"
+            echo ""
+            echo "Generated by ${RUN_SOURCE} auto-vuln-fix workflow."
+            echo ""
+            echo "### Build Status"
+            echo "$BUILD_BADGE"
+            echo ""
+            if [ -f vuln-fix-summary.md ]; then
+              cat vuln-fix-summary.md
+            else
+              echo "No summary file found."
+            fi
+            if [ -s review-queue.md ]; then
+              echo ""
+              cat review-queue.md
+            fi
+          } > pr-body.md
+
+      - name: Create or update auto-fix PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ needs.resolve-config.outputs.target_branch }}
+          commit-message: "fix: automated vulnerability remediation"
+          branch: "auto-fix-vulns-daily"
+          branch-suffix: timestamp
+          delete-branch: false
+          title: "fix: automated vulnerability remediation"
+          body-path: pr-body.md
+          labels: |
+            security
+            automated
+          # konk does not commit vendor/ — only commit module manifests.
+          add-paths: |
+            cmd/konk-service/go.mod
+            cmd/konk-service/go.sum
+            cmd/provision/go.mod
+            cmd/provision/go.sum


### PR DESCRIPTION
## Description

Adds a Wiz-based vulnerability scan and automatic Go module remediation pipeline for konk's Go services. Ported from [Infoblox-CTO/atlas.notifications.sender#100](https://github.com/Infoblox-CTO/atlas.notifications.sender/pull/100), adapted for konk's multi-module layout.

## What's added

- `.github/workflows/auto-vuln-fix.yml` — daily 01:00 UTC scheduled workflow (also runnable on demand via `workflow_dispatch`) that:
  1. Builds scan images for each target listed in `SCAN_TARGETS`
  2. Runs `wizcli` against each image and merges findings
  3. Recommends safe fix versions, scores risk, and builds an `auto_apply` allowlist
  4. Applies allowlisted fixes **per Go module** (`cd "$module_dir"` for each target)
  5. Validates the rebuild per module
  6. Opens/updates a PR (`auto-fix-vulns-daily`) with the changes and a markdown summary
- `.github/skills/go-vuln-remediate/SKILL.md` — agent runbook for local/CI execution
- `.github/skills/go-vuln-remediate/konk/service-config.env` — konk-specific config; `SCAN_TARGETS` uses a 5-field schema (`name|dockerfile|build_path|image_tag|module_dir`) to support konk's per-`cmd/*` modules
- `.github/skills/go-vuln-remediate/references/workflow-mapping.md` — workflow ↔ skill mapping reference
- `.github/skills/go-vuln-remediate/scripts/{grype-parse,parse-fix,risk-score,version-selector,wiz-json-parse}.sh` — generic scanner/parser/fixer scripts (copied verbatim from the source PR)

## Scan targets

| Target | Module dir | Dockerfile | Image tag |
|---|---|---|---|
| `konk-service` | `cmd/konk-service` | `Dockerfile.konk-service` | `konk-service` |
| `konk-provision` | `cmd/provision` | `Dockerfile.provision` | `konk-provision` |

## Out of scope for auto-fix (documented in config + SKILL.md)

- **konk operator image** (root `Dockerfile`) — builds `operator-sdk` `helm-operator` from upstream source; CVEs require bumping the pinned operator-sdk tag.
- **konk-app image** (`build/kubernetes/Dockerfile`) — patched kube-apiserver fork; CVEs require bumping `K8S_RELEASE` in the Makefile.

## Key adaptations vs. source PR

| Aspect | atlas.notifications.sender | konk |
|---|---|---|
| Default branch | `master` | `main` |
| Go module layout | Single root `go.mod` | No root `go.mod`; one per `cmd/<name>/` |
| `SCAN_TARGETS` schema | 4 fields | 5 fields (adds `module_dir`) |
| Scan targets | 1 image | 2 images |
| `setup-go` source | `go-version-file: go.mod` | `go-version-file: cmd/konk-service/go.mod`; caches both module `go.sum`s |
| Apply step | Single call at repo root | Loops per target, `cd "$module_dir"`, calls `parse-fix.sh` with absolute artifact paths, concatenates per-module summaries |
| Verify build | `go build … "$SERVER_BUILD_PATH"` from root | Loops per target: `( cd "$module_dir" && go build … "$build_path" )` |
| Diff detection | `go.mod go.sum vendor` | Per-module `go.mod`/`go.sum`; also flags untracked `go.sum` |
| PR `add-paths` | `go.mod`, `go.sum`, `vendor` | Per-module `go.mod` + `go.sum` (no `vendor/` — konk doesn't vendor) |

## Required repo configuration before first run

1. **Secrets**: `WIZ_CLIENT_ID`, `WIZ_CLIENT_SECRET` (workflow gracefully skips if missing); optional `HARBOR_SERVICES_PROD_USERNAME` / `HARBOR_SERVICES_PROD_PASSWORD`, `GITPAT`.
2. **Variable** (optional): `vars.TARGET_BRANCH` — defaults to `main`.

## Validation done locally

- `bash -n` on all 5 scripts → OK
- `python3 -c "yaml.safe_load(...)"` on `.github/workflows/auto-vuln-fix.yml` → OK

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Additional info

- [ ] My change requires a change to the documentation
- [x] I have added tests to cover my changes (the workflow itself is the test harness; it will scan and report whether fixes apply cleanly)
