### PR TITLE
fix: skip Harbor login in auto-vuln-fix workflow

### DIFF
--- a/.github/skills/go-vuln-remediate/konk/service-config.env
+++ b/.github/skills/go-vuln-remediate/konk/service-config.env
@@ -37,7 +37,8 @@ SCAN_TARGETS="konk-service|Dockerfile.konk-service|.|konk-service|cmd/konk-servi
 ARTIFACT_RETENTION_DAYS="30"
 
 # Optional registry credentials
-HARBOR_REGISTRY=harbor.services.sdp.infoblox.com
+# Harbor login is not needed — all base images are public (golang, distroless).
+HARBOR_REGISTRY=""
 # HARBOR_SERVICES_PROD_USERNAME=...
 # HARBOR_SERVICES_PROD_PASSWORD=...
 


### PR DESCRIPTION
All Dockerfile base images (golang, distroless) are public — no Harbor credentials needed for the scan workflow.