### PR TITLE
ci: promote GHCR images to Harbor

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # required by actions/attest-build-provenance
+      attestations: write   # required by actions/attest-build-provenance
     steps:
     - uses: actions/checkout@v4
       with:
@@ -61,3 +63,40 @@ jobs:
             sleep 10
           done
         done
+
+    - name: Collect image digests
+      id: digests
+      run: |
+        GIT_VERSION=$(git describe --always --long --tags)
+        for img in konk konk-app konk-provision konk-service; do
+          digest=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/infobloxopen/${img}:${GIT_VERSION} | cut -d'@' -f2)
+          echo "${img}=${digest}" >> "$GITHUB_OUTPUT"
+        done
+
+    - name: Attest provenance — konk
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ghcr.io/infobloxopen/konk
+        subject-digest: ${{ steps.digests.outputs.konk }}
+        push-to-registry: true
+
+    - name: Attest provenance — konk-app
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ghcr.io/infobloxopen/konk-app
+        subject-digest: ${{ steps.digests.outputs.konk-app }}
+        push-to-registry: true
+
+    - name: Attest provenance — konk-provision
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ghcr.io/infobloxopen/konk-provision
+        subject-digest: ${{ steps.digests.outputs.konk-provision }}
+        push-to-registry: true
+
+    - name: Attest provenance — konk-service
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ghcr.io/infobloxopen/konk-service
+        subject-digest: ${{ steps.digests.outputs.konk-service }}
+        push-to-registry: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,13 @@ pipeline {
   agent {
     label 'ubuntu_docker_label'
   }
+  parameters {
+    booleanParam(
+      name: 'HARBOR_PROMOTION_DRY_RUN',
+      defaultValue: true,
+      description: 'If true, only print planned GHCR->Harbor promotions; no copy/sign is performed.'
+    )
+  }
   environment {
     HELM_IMAGE = "infoblox/helm:3.2.4-5b243a2"
     HELM="""docker run --rm \
@@ -35,6 +42,101 @@ pipeline {
           sh '''
             make -C test/apiserver push
           '''
+        }
+      }
+    }
+    stage("Promote Images To Harbor") {
+      when {
+        anyOf {
+          branch 'main'
+          branch 'ci'
+          branch 'release/*'
+        }
+      }
+      steps {
+        sh '''#!/bin/bash
+          set -euo pipefail
+
+          CRANE_VERSION=v0.20.3
+          curl -sL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar xz -C /tmp crane
+          chmod +x /tmp/crane
+
+          COSIGN_VERSION=v2.4.3
+          curl -sL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" -o /tmp/cosign
+          chmod +x /tmp/cosign
+
+          GH_VERSION=2.67.0
+          curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | tar xz -C /tmp --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh"
+          chmod +x /tmp/gh
+        '''
+
+        script {
+          def ghcrPrefix = 'ghcr.io/infobloxopen'
+          def harborPrefix = 'harbor.services.sdp.infoblox.com/infobloxcto'
+          def images = ['konk', 'konk-app', 'konk-provision', 'konk-service']
+
+          if (params.HARBOR_PROMOTION_DRY_RUN) {
+            // Dry-run is non-blocking for first rollout.
+            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+              sh """#!/bin/bash
+                set -euo pipefail
+                TAG='${env.GIT_VERSION}'
+                echo 'Harbor promotion dry-run enabled; no copy/sign will be performed.'
+                for name in ${images.join(' ')}; do
+                  src='${ghcrPrefix}/'"\${name}"':"\${TAG}"'
+                  dst='${harborPrefix}/'"\${name}"':"\${TAG}"'
+                  digest=$(/tmp/crane digest "\${src}" 2>/dev/null || true)
+                  if [[ -n "\${digest}" ]]; then
+                    echo "DRY-RUN: would promote \${src} -> \${dst} (digest=\${digest})"
+                  else
+                    echo "DRY-RUN: would promote \${src} -> \${dst} (digest lookup failed)"
+                  fi
+                done
+              """
+            }
+          } else {
+            withCredentials([
+              string(credentialsId: 'GITHUB_TOKEN', variable: 'GITHUB_PAT'),
+              usernamePassword(credentialsId: 'harbor-services-prod',
+                               usernameVariable: 'HARBOR_USERNAME',
+                               passwordVariable: 'HARBOR_PASSWORD'),
+              [$class: 'VaultTokenCredentialBinding',
+               credentialsId: 'vault-services-prod-cosign',
+               vaultAddr: 'https://vault.services.sdp.infoblox.com:8200'],
+            ]) {
+              sh """#!/bin/bash
+                set -euo pipefail
+
+                echo "\${GITHUB_PAT}" | /tmp/crane auth login ghcr.io -u ibciteam --password-stdin
+                echo "\${HARBOR_PASSWORD}" | /tmp/crane auth login harbor.services.sdp.infoblox.com -u "\${HARBOR_USERNAME}" --password-stdin
+
+                TAG='${env.GIT_VERSION}'
+                for name in ${images.join(' ')}; do
+                  src='${ghcrPrefix}/'"\${name}"':"\${TAG}"'
+                  dst='${harborPrefix}/'"\${name}"':"\${TAG}"'
+
+                  digest=$(/tmp/crane digest "\${src}")
+                  echo "Verifying SLSA provenance for \${src}@\${digest}"
+                  GH_TOKEN="\${GITHUB_PAT}" /tmp/gh attestation verify \
+                    "oci://${ghcrPrefix}/\${name}@\${digest}" \
+                    --repo 'infobloxopen/konk' \
+                    --predicate-type https://slsa.dev/provenance/v1 \
+                    --bundle-from-oci \
+                    --cert-identity-regex '^https://github\\.com/infobloxopen/konk/\\.github/workflows/push-images\\.yml@refs/heads/(main|release/.+)\$'
+
+                  echo "Promoting \${src} -> \${dst}"
+                  /tmp/crane copy "\${src}" "\${dst}"
+
+                  /tmp/cosign sign \
+                    --key 'hashivault://harbor-cosign' \
+                    --yes \
+                    '${harborPrefix}/'"\${name}"'@'"\${digest}"
+                done
+              """
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a Jenkins Harbor promotion stage that copies Konk images from GHCR to Harbor
- add a safe dry-run rollout mode for Harbor promotion in Jenkins
- emit GHCR provenance attestations in GitHub Actions and verify them before Harbor promotion

## What changed
- add `HARBOR_PROMOTION_DRY_RUN` Jenkins parameter, defaulting to `true`
- install `crane`, `cosign`, and `gh` in the promotion stage
- promote `konk`, `konk-app`, `konk-provision`, and `konk-service` from `ghcr.io/infobloxopen` to `harbor.services.sdp.infoblox.com/infobloxcto`
- sign Harbor images by digest using `hashivault://harbor-cosign`
- add SLSA provenance attestations for all four GHCR images in `.github/workflows/push-images.yml`
- verify GHCR provenance in Jenkins with `gh attestation verify --bundle-from-oci` before copying to Harbor

## Why
The current flow requires a follow-up change in the Charts repo to update `charts/konk/image_list` before Harbor receives the new Konk images. This change moves Harbor promotion into the Konk repo itself and follows the same promotion pattern already used in `upstream-artifact-foundry`.

## Rollout / safety
- the new Harbor promotion stage is non-destructive by default because `HARBOR_PROMOTION_DRY_RUN=true`
- dry-run mode only resolves and prints planned source/destination image refs and digests
- real promotion requires explicitly running with `HARBOR_PROMOTION_DRY_RUN=false`
- provenance verification fails the real promotion path before any Harbor copy occurs if the GHCR attestation is missing or invalid

## Validation
- verified no editor diagnostics in `Jenkinsfile`
- verified no editor diagnostics in `.github/workflows/push-images.yml`
- reviewed the resulting git diff for both files

## Notes
- local Wiz scan artifacts and other untracked files were intentionally not included in this PR
- the first real promotion run should happen only after `push-images.yml` has run once on `main` or `release/**` and published provenance bundles to GHCR
