### PR TITLE
Log actual Helm error on upgrade failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ RUN apk add --no-cache git make bash
 
 # Clone and build operator-sdk/helm-operator
 WORKDIR /workspace
+COPY patches/ /workspace/patches/
 RUN git clone --depth 1 --branch v1.42.0 https://github.com/operator-framework/operator-sdk.git && \
     cd operator-sdk && \
+    git apply /workspace/patches/operator-sdk-upgrade-error-logging.patch && \
     go get golang.org/x/crypto@v0.52.0 \
            golang.org/x/net@v0.55.0 \
            google.golang.org/grpc@v1.79.3 \

--- a/patches/operator-sdk-upgrade-error-logging.patch
+++ b/patches/operator-sdk-upgrade-error-logging.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/helm/release/manager.go b/internal/helm/release/manager.go
+index cc893df..b72ce40 100644
+--- a/internal/helm/release/manager.go
++++ b/internal/helm/release/manager.go
+@@ -229,9 +229,8 @@ func (m manager) UpgradeRelease(opts ...UpgradeOption) (*rpb.Release, *rpb.Relea
+ 			// Therefore, we should perform the rollback when we have a non-nil
+ 			// release. Any rollback error here would be unexpected, so always
+ 			// log both the upgrade and rollback errors.
+-			fmt.Printf("release upgrade failed; %v", err)
+
+-			return nil, nil, ErrUpgradeFailed
++			return nil, nil, fmt.Errorf("%w: %v", ErrUpgradeFailed, err)
+ 		}
+ 		return nil, nil, fmt.Errorf("failed to upgrade release: %w", err)
+ 	}


### PR DESCRIPTION
## Summary
- Operator-sdk's `UpgradeRelease()` drops the real Helm upgrade error (hook timeout, resource conflict, etc.) and replaces it with a bare sentinel `"upgrade failed; rollback required"`
- The actual error was printed to stdout via `fmt.Printf` — invisible in structured JSON logs
- This patch wraps the underlying Helm error into `ErrUpgradeFailed` via `fmt.Errorf("%w: %v", ErrUpgradeFailed, err)` so the real cause propagates into operator logs and CR status conditions

## Before
```
{"level":"error","msg":"Release failed","error":"upgrade failed; rollback required"}
```

## After
```
{"level":"error","msg":"Release failed","error":"upgrade failed; rollback required: pre-upgrade hook \"bulk-konk-etcd-fix-helm-orphans\" failed: job failed: BackoffLimitExceeded"}
```

## Context
Discovered while debugging etcd upgrade failure on us-dev-4 where the upgrade error was completely opaque — required manual correlation of events, Jobs, and webhook logs across namespaces to find the root cause (VPC admission webhook blocking hook pods).

## Test plan
- [ ] Docker build succeeds with patch applied
- [ ] Deploy to dev cluster and trigger an upgrade — verify operator logs include the underlying Helm error
- [ ] Verify `errors.Is(err, ErrUpgradeFailed)` still works (rollback path still triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)