### PR TITLE
fix(konk-operator): fall back to appVersion for relatedImages tags

### DIFF
--- a/helm-charts/konk-operator/templates/deployment.yaml
+++ b/helm-charts/konk-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- if .Values.initOrphanFix.enabled }}
       initContainers:
         - name: fix-helm-orphans
-          image: "{{ include "konk-operator.imageRepo" (dict "ctx" . "repo" .Values.relatedImages.kindRepository) }}:{{ .Values.relatedImages.kind }}"
+          image: "{{ include "konk-operator.imageRepo" (dict "ctx" . "repo" .Values.relatedImages.kindRepository) }}:{{ .Values.relatedImages.kind | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/konk-service", "fix-helm-orphans-init"]
           {{- if .Values.initOrphanFix.skip }}
@@ -68,11 +68,11 @@ spec:
             - name: VAULT_PATH
               value: {{ .Values.vaultCommon.imagepullsecret.path | default "" }}
             - name: RELATED_IMAGE_APISERVER
-              value: {{ .Values.relatedImages.apiserver | default "" | quote }}
+              value: {{ .Values.relatedImages.apiserver | default .Chart.AppVersion | quote }}
             - name: RELATED_IMAGE_PROVISION
-              value: {{ .Values.relatedImages.provision | default "" | quote }}
+              value: {{ .Values.relatedImages.provision | default .Chart.AppVersion | quote }}
             - name: RELATED_IMAGE_KIND
-              value: {{ .Values.relatedImages.kind | default "" | quote }}
+              value: {{ .Values.relatedImages.kind | default .Chart.AppVersion | quote }}
             - name: RELATED_IMAGE_APISERVER_REPO
               value: {{ include "konk-operator.imageRepo" (dict "ctx" . "repo" .Values.relatedImages.apiserverRepository) | quote }}
             - name: RELATED_IMAGE_PROVISION_REPO


### PR DESCRIPTION
## Problem

`values.yaml` documents the `relatedImages` tags as overriding *"the chart's default appVersion fallback"*, but the template never implemented one. With a tag unset, the rendered reference is a bare `repo:` with an empty tag:

```
image: "ghcr.io/infobloxopen/konk-service:"
```

Kubernetes rejects that. For the `fix-helm-orphans` init container it means the pod never starts at all, since a failing init container blocks the main container — so the operator doesn't come up rather than losing one feature.

## Fix

`make package` builds the chart with `--app-version ${GIT_VERSION}`, and the four component images are tagged with that same `git describe` version. So `.Chart.AppVersion` in a packaged chart is already exactly the right tag — use it as the fallback.

This mirrors how `image.tag` has always resolved (`.Values.image.tag | default .Chart.AppVersion`), so the operator's own image and the components it deploys now behave consistently. Explicitly set tags keep taking precedence.

## Behaviour change

Deployments that set these tags explicitly are unaffected. Deployments that leave them unset previously rendered an unusable empty tag and now resolve to the chart's own version — the documented behaviour.

Note a source-tree render shows `0.1.0`, the placeholder `appVersion` in `Chart.yaml`; `make package` always overwrites it, so that value never reaches a cluster.

## Test plan

- [x] `helm lint` passes
- [x] Packaged chart with no tags set renders the real version: `konk-service:v0.2.1-165-g27f1ba0`
- [x] Explicitly set tags still win
- [x] Verified with and without a registry mirror host configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)