### PR TITLE
fix(konk-operator): restore crds.create default to false

### DIFF
--- a/helm-charts/konk-operator/values.yaml
+++ b/helm-charts/konk-operator/values.yaml
@@ -82,7 +82,7 @@ cert-manager:
   namespace: cert-manager
 
 crds:
-  create: true
+  create: false
 
 dashboards:
   create: false


### PR DESCRIPTION
Fixes the End-To-End failures introduced by #675.

## Problem

#675 changed `crds.create` from `false` to `true`. That breaks the Makefile install path CI uses:

```
make deploy-crds           # kubectl apply -f helm-charts/konk-operator/crds
make deploy-konk-operator  # helm upgrade -i
```

`deploy-crds` applies the CRDs outside Helm, on purpose — the target carries the note *"There is no support at this time for upgrading or deleting CRDs using Helm."* With `crds.create` defaulting to `true`, the packaged chart renders the same CRDs into the release, so Helm tries to adopt resources it doesn't own:

```
Error: Unable to continue with install: CustomResourceDefinition
"etcds.konk.infoblox.com" in namespace "" exists and cannot be imported into
the current release: invalid ownership metadata; label validation error:
missing key "app.kubernetes.io/managed-by": must be set to "Helm"
```

## Why the default was wrong

The value looked universal because deployments do set it — but those install the chart *without* applying CRDs separately, so Helm legitimately owns them there. Two install paths, two different correct answers. Reverting the default restores the Makefile/CI path; deployments that set `crds.create` explicitly are unaffected.

## Why tests didn't catch it

`templates/crds.yaml` globs `crds/*.yaml`, which is empty in a source checkout and only populated by `make package` from `config/crd/bases`. So `helm template` and `helm lint` render zero CRDs regardless of the flag, and only a packaged install reproduces the conflict.

## Test plan

- [x] `helm lint` passes
- [x] Packaged chart renders 3 CRDs with `crds.create=true`, 0 with `false` — confirming the conflict source
- [ ] End-To-End jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)