### PR TITLE
feat(etcd): expose Prometheus metrics via PodMonitor on dedicated port

### DIFF
--- a/helm-charts/etcd/dashboards/etcd.json
+++ b/helm-charts/etcd/dashboards/etcd.json
@@ -1,0 +1,593 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS_UID",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.19"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Pod Restarts",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Unix timestamp of when each etcd process started. A step-jump (any pod, leader or follower) means that pod was recreated.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "process_start_time_seconds{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Start Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Per pod: 1 = leader visible, 0 = pod sees no leader (disrupted). Drops to 0 on the restarting pod during recreation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [
+            { "options": { "0": { "color": "red", "index": 0, "text": "No leader" }, "1": { "color": "green", "index": 1, "text": "Has leader" } }, "type": "value" }
+          ],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "etcd_server_has_leader{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Has Leader (per pod)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 10,
+      "panels": [],
+      "title": "Cluster Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Rate of leader elections. Spikes indicate a leader-disrupting pod restart or network partition.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
+      "id": 11,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "increase(etcd_server_leader_changes_seen_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Leader Changes Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Failed Raft proposals. Non-zero sustained values indicate write failures during a restart window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "etcd_server_proposals_failed_total{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}} failed",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "etcd_server_proposals_pending{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}} pending",
+          "refId": "B"
+        }
+      ],
+      "title": "Proposals Failed / Pending",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Peer round-trip latency p99. High values indicate network issues between etcd members, which can precede instability.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer RTT p99",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 20,
+      "panels": [],
+      "title": "Performance & Storage",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "WAL fsync latency p99. Values above 10ms indicate disk pressure and can cause etcd to become unhealthy.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.01 }, { "color": "red", "value": 0.1 }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 21,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Sync Latency p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "Backend commit latency p99. High values indicate MVCC/snapshot pressure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.025 }, { "color": "red", "value": 0.1 }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "id": 22,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Commit Latency p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+      "description": "etcd MVCC database size. Allocated = total file size; In-use = live data. Growing gap means compaction is needed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "id": 23,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "etcd_mvcc_db_total_size_in_bytes{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}} allocated",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "etcd_mvcc_db_total_size_in_use_in_bytes{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{pod}} in-use",
+          "refId": "B"
+        }
+      ],
+      "title": "DB Size",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["etcd", "konk"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+        "definition": "label_values(etcd_server_has_leader, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(etcd_server_has_leader, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+        "definition": "label_values(etcd_server_has_leader{namespace=\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(etcd_server_has_leader{namespace=\"$namespace\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "etcd",
+  "uid": "etcd-konk-infoblox",
+  "version": 1
+}

--- a/helm-charts/etcd/dashboards/etcd.json
+++ b/helm-charts/etcd/dashboards/etcd.json
@@ -117,10 +117,10 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-      "description": "Per pod: 1 = leader visible, 0 = pod sees no leader (disrupted). Drops to 0 on the restarting pod during recreation.",
+      "description": "Number of etcd pods in Ready state. Normal = 3. Drops to 2 during a rolling restart (still quorate). Drops to 1 = quorum at risk.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": { "mode": "fixed", "fixedColor": "green" },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -129,7 +129,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": { "legend": false, "tooltip": false, "viz": false },
             "insertNulls": false,
@@ -140,17 +140,19 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "thresholdsStyle": { "mode": "line+area" }
           },
           "links": [],
-          "mappings": [
-            { "options": { "0": { "color": "red", "index": 0, "text": "No leader" }, "1": { "color": "green", "index": 1, "text": "Has leader" } }, "type": "value" }
-          ],
-          "max": 1,
+          "mappings": [],
+          "max": 3,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0 }]
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "green", "value": 3 }
+            ]
           }
         },
         "overrides": []
@@ -165,12 +167,18 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "etcd_server_has_leader{namespace=\"$namespace\", pod=~\"$pod\"}",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"true\"})",
+          "legendFormat": "ready",
           "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
+          "expr": "sum(kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"false\"})",
+          "legendFormat": "not ready",
+          "refId": "B"
         }
       ],
-      "title": "Has Leader (per pod)",
+      "title": "Pods Ready",
       "type": "timeseries"
     },
     {

--- a/helm-charts/etcd/templates/dashboard.yaml
+++ b/helm-charts/etcd/templates/dashboard.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dashboards.create }}
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    integreatly.org/operator: appinfra-grafana
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
+spec:
+  customFolderName: "konk"
+  json: |-
+    {{- .Files.Get "dashboards/etcd.json" | replace "${DS_PROMETHEUS_UID}" .Values.dashboards.prometheusUid | nindent 4 }}
+{{- end }}

--- a/helm-charts/etcd/templates/podmonitor.yaml
+++ b/helm-charts/etcd/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "etcd.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.podMonitor.scrapeTimeout }}
+{{- end }}

--- a/helm-charts/etcd/templates/statefulset.yaml
+++ b/helm-charts/etcd/templates/statefulset.yaml
@@ -102,6 +102,10 @@ spec:
               value: "existing"
               {{- end }}
             {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: ETCD_LISTEN_METRICS_URLS
+              value: "http://0.0.0.0:{{ .Values.metrics.port }}"
+            {{- end }}
             {{- if .Values.etcd.autoCompactionMode }}
             - name: ETCD_AUTO_COMPACTION_MODE
               value: {{ .Values.etcd.autoCompactionMode | quote }}
@@ -147,6 +151,11 @@ spec:
             - name: peer
               containerPort: {{ .Values.service.peerPort }}
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             {{- if and .Values.auth.client.secureTransport .Values.auth.client.enableAuthentication }}

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -147,3 +147,8 @@ metrics:
     enabled: false
     interval: 60s
     scrapeTimeout: 10s
+
+## @section Dashboard parameters
+dashboards:
+  create: false
+  prometheusUid: "000000001"

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -139,6 +139,11 @@ clusterDomain: cluster.local
 ## @section Metrics parameters
 metrics:
   enabled: false
+  port: 2381
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "2379"
+    prometheus.io/port: "2381"
+  podMonitor:
+    enabled: false
+    interval: 60s
+    scrapeTimeout: 10s


### PR DESCRIPTION
## Summary

- **Problem**: The etcd Helm chart had no working metrics endpoint. The existing `metrics` stub pointed pod annotations at port `2379` (the mTLS client port), which Prometheus/Alloy cannot scrape without TLS certificates. No `ETCD_LISTEN_METRICS_URLS` was set, so etcd never opened a plain HTTP metrics endpoint. There was also no dashboard for etcd health visibility.
- **Root cause discovery**: Investigated the cluster and found the metrics collector is **Grafana Alloy** (`infra-monitoring-v3`), not appinfra-prometheus. Alloy uses `prometheus.operator.podmonitors` — it picks up PodMonitor CRDs cluster-wide with no label restrictions. ServiceMonitors are not supported in this stack.
- **Fix**: Opt-in metrics endpoint on port 2381, PodMonitor for Alloy, and a Grafana dashboard for etcd health and pod restart debugging.

## Changes

### `values.yaml`
- Added `metrics.port: 2381` — dedicated plain HTTP metrics port (separate from the TLS client port 2379)
- Fixed `metrics.podAnnotations` port from `2379` → `2381`
- Added `metrics.podMonitor` block (`enabled`, `interval`, `scrapeTimeout`)
- Added `dashboards` block (`create: false`, `prometheusUid`)

### `templates/statefulset.yaml`
- Added `ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:{{ .Values.metrics.port }}` env var when `metrics.enabled: true` — opens the plain HTTP scrape endpoint in etcd
- Added `metrics` container port `2381` when `metrics.enabled: true`

### `templates/podmonitor.yaml` _(new)_
- PodMonitor targeting etcd pods directly via the `metrics` port
- Alloy auto-discovers it cluster-wide with no label selector requirements

### `templates/dashboard.yaml` _(new)_
- `GrafanaDashboard` CR (integreatly.org/v1alpha1), gated on `dashboards.create`
- Same pattern as `helm-charts/konk-operator` — label `integreatly.org/operator: appinfra-grafana`, folder `konk`
- Prometheus UID substituted at Helm render time via `dashboards.prometheusUid`

### `dashboards/etcd.json` _(new)_
Grafana 10 compatible dashboard (schemaVersion 39, all `timeseries` panels).

#### Dashboard variables
| Variable | Query | Purpose |
|----------|-------|---------|
| `namespace` | `label_values(etcd_server_has_leader, namespace)` | Filter to the namespace the etcd StatefulSet runs in |
| `pod` | `label_values(etcd_server_has_leader{namespace="$namespace"}, pod)` | Multi-select individual pods (e.g. `bulk-konk-etcd-1`) |

#### Row 1 — Pod Restarts
The primary debugging view for tracking when and which etcd pod was recreated.

| Panel | Metric | How to read it |
|-------|--------|----------------|
| **Pod Start Time** | `process_start_time_seconds` | Each pod is a separate line. A sudden **step-jump** in any line means that pod was recreated. Catches **both leader and follower** restarts — unlike `etcd_server_leader_changes_seen_total` which only increments on leader elections. |
| **Pods Ready** | `kube_pod_status_ready` | Shows count of ready vs not-ready pods. Normal steady-state = `3` (green). Drops to `2` (yellow) during a rolling restart — cluster remains quorate. Drops to `1` or `0` (red) = quorum at risk. |

> **Why `process_start_time_seconds` and not `etcd_server_leader_changes_seen_total`?**
> A follower pod recreation does not trigger a leader election, so `leader_changes_seen_total` stays flat and the restart is invisible. `process_start_time_seconds` is emitted per-pod and always reflects the actual process start time regardless of role.

#### Row 2 — Cluster Health
Impact view — did the restart actually disrupt the cluster?

| Panel | Metric | How to read it |
|-------|--------|----------------|
| **Leader Changes Rate** | `increase(etcd_server_leader_changes_seen_total[$__rate_interval])` | Spikes when a leader pod is replaced or when a network partition causes re-election. Flat = follower-only restart with no disruption. |
| **Proposals Failed / Pending** | `etcd_server_proposals_failed_total`, `etcd_server_proposals_pending` | Non-zero failed proposals = write failures during the restart window. Pending spike = backlog building up while quorum was reduced. |
| **Peer RTT p99** | `histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[...]))` | Per-peer pair latency. Elevated values before a restart often indicate the node was under pressure before eviction. |

#### Row 3 — Performance & Storage
Underlying health indicators — useful for root-causing why a pod was evicted or killed.

| Panel | Metric | How to read it |
|-------|--------|----------------|
| **WAL Sync Latency p99** | `etcd_disk_wal_fsync_duration_seconds` | Values consistently above 10ms indicate disk I/O pressure. etcd's liveness probe can time out under high WAL latency, causing a restart. |
| **Backend Commit Latency p99** | `etcd_disk_backend_commit_duration_seconds` | High values indicate MVCC/snapshot pressure, often from unbounded key growth. |
| **DB Size** | `etcd_mvcc_db_total_size_in_bytes` (allocated) vs `etcd_mvcc_db_total_size_in_use_in_bytes` (in-use) | A growing gap between allocated and in-use means compaction is not reclaiming space. Unbounded growth will eventually exhaust the PVC and crash etcd. |

## Usage

Enable metrics + PodMonitor in konk values:
```yaml
metrics:
  enabled: true
  podMonitor:
    enabled: true
```

Enable dashboard (set correct Prometheus UID for the cluster):
```yaml
dashboards:
  create: true
  prometheusUid: "<grafana-prometheus-datasource-uid>"
```

All flags default to `false` — no resources are created unless explicitly opted in.

## Test plan

- [ ] Deploy a konk instance with `metrics.enabled: true` and `metrics.podMonitor.enabled: true`
- [ ] Verify etcd pod exposes `/metrics` on port `2381`: `kubectl port-forward -n <ns> <etcd-pod> 9381:2381 && curl http://localhost:9381/metrics | head`
- [ ] Verify PodMonitor CR is created in the namespace
- [ ] Confirm Alloy picks up the target — query `up{job=~".*etcd.*"}` in Grafana
- [ ] Deploy with `dashboards.create: true` — confirm `GrafanaDashboard` CR appears and dashboard shows in Grafana under the `konk` folder
- [ ] Select `namespace` and `pod` variables in the dashboard — confirm panels populate with per-pod data
- [ ] Trigger a rolling restart; verify **Pod Start Time** shows a step-jump per pod and **Pods Ready** drops 3→2→3
- [ ] Confirm **Leader Changes Rate** spikes only when the leader pod is restarted, stays flat for follower restarts
- [ ] Verify no regression with defaults (`metrics.enabled: false`, `dashboards.create: false`) — no extra resources created

🤖 Generated with [Claude Code](https://claude.com/claude-code)