### PR TITLE
fix(etcd): raise CPU request to 200m and add PodDisruptionBudget

### DIFF
--- a/helm-charts/etcd/Chart.yaml
+++ b/helm-charts/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: etcd
 description: A custom etcd Helm chart using upstream etcd images
-version: 1.1.0
+version: 1.2.0
 appVersion: "3.7.0"
 type: application
 

--- a/helm-charts/etcd/templates/poddisruptionbudget.yaml
+++ b/helm-charts/etcd/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.pdb.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "etcd.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -94,8 +94,13 @@ resources:
   limits:
     memory: 2Gi
   requests:
-    cpu: 100m
+    cpu: 200m
     memory: 256Mi
+
+## @section PodDisruptionBudget parameters
+pdb:
+  enabled: true
+  minAvailable: 2
 
 ## @section Probe parameters
 livenessProbe:

--- a/helm-charts/konk-service/Chart.yaml
+++ b/helm-charts/konk-service/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.25.8
 description: Registers an aggregate API service in Konk
 name: konk-service
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -1,6 +1,6 @@
 # konk-service
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
 
 Registers an aggregate API service in Konk
 
@@ -12,6 +12,10 @@ When deploying with `helm install`, these configurations are values and can be o
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key | string | `"node-group-type"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator | string | `"In"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0] | string | `"stable"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | annotations | object | `{}` | annotations to add to the APIService created in Konk by KonkService |
 | crds | string | `nil` |  |
 | fullnameOverride | string | `""` |  |
@@ -26,7 +30,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | ingress.hosts[0].host | string | `"localhost"` |  |
 | ingress.tls | list | `[]` |  |
 | insecureSkipTLSVerify | bool | `false` |  |
-| kind | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/infobloxopen/konk-service","tag":""},"resources":{"limits":{"memory":"256Mi"},"requests":{"cpu":"10m","memory":"32Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}}` | konk-service Go binary image (replaces konk-tools shell-based containers) Contains a single statically-linked Go binary on a distroless base. No shell, no busybox — all kubectl/shell logic is implemented in Go. |
+| kind | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/infobloxopen/konk-service","tag":""},"resources":{"limits":{"memory":"256Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}}` | konk-service Go binary image (replaces konk-tools shell-based containers) Contains a single statically-linked Go binary on a distroless base. No shell, no busybox — all kubectl/shell logic is implemented in Go. |
 | kind.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | konk.name | string | `""` | should be set to the konk-name |
 | konk.namespace | string | `""` |  |
@@ -38,4 +42,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | space.enabled | bool | `false` |  |
+| tolerations[0].effect | string | `"NoSchedule"` |  |
+| tolerations[0].key | string | `"infoblox.com/do-not-disrupt"` |  |
+| tolerations[0].operator | string | `"Exists"` |  |
 | version | string | `"v1alpha1"` |  |

--- a/helm-charts/konk-service/templates/apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-deployment.yaml
@@ -23,6 +23,14 @@ spec:
         app.kubernetes.io/component: apiservice
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: apiservice
         securityContext:

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -23,6 +23,14 @@ spec:
         app.kubernetes.io/component: apiservice-test
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: apiservice-test
         securityContext:

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -22,6 +22,14 @@ spec:
         app.kubernetes.io/component: kubeconfig
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kubeconfig
         securityContext:

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -33,7 +33,7 @@ kind:
     limits:
       memory: 256Mi
     requests:
-      cpu: 10m
+      cpu: 100m
       memory: 32Mi
   securityContext:
     readOnlyRootFilesystem: true
@@ -42,6 +42,22 @@ kind:
     capabilities:
       drop:
         - ALL
+
+tolerations:
+  - key: infoblox.com/do-not-disrupt
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: node-group-type
+              operator: In
+              values:
+                - stable
 
 ingress:
   enabled: false

--- a/helm-charts/konk/Chart.yaml
+++ b/helm-charts/konk/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.25.8
 description: Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 name: konk
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -50,7 +50,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | etcd.replicaCount | int | `3` |  |
 | etcd.resources.limits.memory | string | `"4Gi"` |  |
 | etcd.resources.requests.cpu | string | `"200m"` |  |
-| etcd.resources.requests.memory | string | `"64Mi"` |  |
+| etcd.resources.requests.memory | string | `"128Mi"` |  |
 | etcd.securityContext.enabled | bool | `true` |  |
 | etcd.securityContext.fsGroup | int | `1001` |  |
 | etcd.securityContext.runAsNonRoot | bool | `true` |  |

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -1,6 +1,6 @@
 # konk
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
 
 Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 
@@ -31,6 +31,10 @@ When deploying with `helm install`, these configurations are values and can be o
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | certManager.namespace | string | `nil` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key | string | `"node-group-type"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator | string | `"In"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0] | string | `"stable"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | etcd.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | etcd.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | etcd.containerSecurityContext.enabled | bool | `true` |  |
@@ -45,12 +49,15 @@ When deploying with `helm install`, these configurations are values and can be o
 | etcd.persistence.size | string | `"8Gi"` |  |
 | etcd.replicaCount | int | `3` |  |
 | etcd.resources.limits.memory | string | `"4Gi"` |  |
-| etcd.resources.requests.cpu | string | `"10m"` |  |
+| etcd.resources.requests.cpu | string | `"200m"` |  |
 | etcd.resources.requests.memory | string | `"64Mi"` |  |
 | etcd.securityContext.enabled | bool | `true` |  |
 | etcd.securityContext.fsGroup | int | `1001` |  |
 | etcd.securityContext.runAsNonRoot | bool | `true` |  |
 | etcd.securityContext.runAsUser | int | `1001` |  |
+| etcd.tolerations[0].effect | string | `"NoSchedule"` |  |
+| etcd.tolerations[0].key | string | `"infoblox.com/do-not-disrupt"` |  |
+| etcd.tolerations[0].operator | string | `"Exists"` |  |
 | fullnameOverride | string | `""` |  |
 | hooks.preInstallUpgrade.enabled | bool | `true` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -66,8 +66,22 @@ etcd:
     limits:
       memory: 4Gi
     requests:
-      cpu: 10m
+      cpu: 200m
       memory: 64Mi
+  tolerations:
+    - key: infoblox.com/do-not-disrupt
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-group-type
+                operator: In
+                values:
+                  - stable
   securityContext:
     enabled: true
     fsGroup: 1001

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -67,7 +67,7 @@ etcd:
       memory: 4Gi
     requests:
       cpu: 200m
-      memory: 64Mi
+      memory: 128Mi
   tolerations:
     - key: infoblox.com/do-not-disrupt
       operator: Exists


### PR DESCRIPTION
## Summary

- **`helm-charts/konk/values.yaml`**: Raises `etcd.resources.requests.cpu` from `10m` to `200m` and `etcd.resources.requests.memory` from `64Mi` to `128Mi` — the actual source of the undersized requests that trigger Karpenter consolidation
- **`helm-charts/konk/values.yaml`**: Adds a soft node affinity (`preferredDuringSchedulingIgnoredDuringExecution`) for `node-group-type=stable` and a toleration for `infoblox.com/do-not-disrupt: NoSchedule` to etcd pods — prefer `stable-node-pool` (WhenEmpty) where it exists; fall back to any node otherwise
- **`helm-charts/konk-service/values.yaml`**: Raises `kind.resources.requests.cpu` from `10m` to `100m`; adds the same soft stable-node-pool affinity and toleration to all KonkService pods
- **`helm-charts/konk-service/templates/`**: Adds `tolerations` and `affinity` rendering to all three deployment templates (`apiservice`, `kubeconfig`, `apiservice-test`)
- **`helm-charts/etcd/templates/poddisruptionbudget.yaml`**: New PDB template with `minAvailable: 2` — enforces quorum-safe evictions at the Kubernetes API level
- **`helm-charts/etcd/values.yaml`**: Adds `pdb.enabled: true` / `pdb.minAvailable: 2` defaults; raises standalone CPU default from `100m` to `200m`
- **Chart versions**: konk `0.1.0 → 0.2.0`, konk-service `0.1.0 → 0.2.0`, etcd `1.1.0 → 1.2.0`

---

## Background

`bulk-konk-etcd` pods in the `aggregate` namespace were being continuously
evicted in a rolling loop by Karpenter's node consolidation on both **us-dev-2**
and **gov-stg-2**. The cycle never stopped on its own:

```
Karpenter marks node as Underutilized (consolidateAfter window expires)
  → evicts etcd pod (Stopping container etcd / Evicted: Underutilized)
  → pod reschedules onto a new node
  → EBS Multi-Attach error — volume still attached to old node (1–2 min delay)
  → pod starts; new node also appears Underutilized (same root cause)
  → [1h / 2h later] — REPEAT
```

On **gov-stg-2**, Karpenter was also evicting KonkService pods directly —
independently of the etcd cycle:

```
ntp  Normal  Evicted  pod/ntp-aggregate-api-apiservice-konk-service-kubeconfig-5bd99jr6pb
             Evicted pod: Underutilized
```

Downstream effect: every eviction triggers a 1–2 minute window where the konk
kube-apiserver loses its backing store (etcd) or its health/reconciliation pods
are canceled mid-check, causing all konk-served API traffic to fail across any
cluster where the loop occurs.

---

## Root Causes

### 1 — etcd and KonkService CPU requests are 10m

The konk chart's defaults for the etcd container and the konk-service chart's
defaults for all KonkService pods were `cpu: 10m`:

```yaml
# helm-charts/konk/values.yaml (before this fix)
etcd:
  resources:
    requests:
      cpu: 10m    # ← far too low
      memory: 64Mi

# helm-charts/konk-service/values.yaml (before this fix)
kind:
  resources:
    requests:
      cpu: 10m    # ← far too low
      memory: 32Mi
```

Karpenter's `WhenEmptyOrUnderutilized` consolidation policy evaluates nodes based
on the **sum of pod resource requests** (not actual usage). With only `10m`
requested, every node hosting a single etcd or KonkService pod looks nearly empty
to Karpenter. Once the `consolidateAfter` window expires (`1h` on us-dev-2, `2h`
on gov-stg-2), Karpenter evicts the pod and terminates the node.

> **Why the etcd chart's own default (100m) didn't help:**
> The konk operator passes `.Values.etcd` from the konk chart directly into the
> Etcd CR spec. The operator then uses that CR spec as helm values when rendering
> the etcd chart — overriding the etcd chart's own defaults. The fix had to be in
> `helm-charts/konk/values.yaml`, not in `helm-charts/etcd/values.yaml`.

### 2 — No PodDisruptionBudget on etcd

```
$ kubectl get pdb -n aggregate
No resources found in aggregate namespace.
```

Without a PDB, Karpenter was free to evict any etcd pod. Quorum (2/3) was only
preserved by Karpenter's own `nodes: 1` disruption budget — a Karpenter-internal
setting, not enforced at the Kubernetes API level. Any other eviction actor
(manual drain, future Karpenter config change) could bypass it entirely.

---

## Changes

### `helm-charts/konk/values.yaml` — etcd CPU, memory, and stable-node-pool affinity

**CPU request: `10m → 200m` | Memory request: `64Mi → 128Mi`**

Global baseline fix for etcd. With `200m` CPU requested, nodes hosting etcd pods
are no longer flagged as underutilized. The `64Mi` memory request was also
undersized relative to actual etcd usage; raised to `128Mi` to reflect observed
consumption. Applies to every cluster running konk.

**Soft node affinity for `stable-node-pool` + matching toleration**

```yaml
etcd:
  tolerations:
    - key: infoblox.com/do-not-disrupt
      operator: Exists
      effect: NoSchedule
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
          preference:
            matchExpressions:
              - key: node-group-type
                operator: In
                values:
                  - stable
```

The `stable-node-pool` on us-dev-2 uses `consolidationPolicy: WhenEmpty` — it
only reclaims nodes after all pods have left naturally, never evicting pods to
consolidate. etcd pods landing there are fully protected from Karpenter eviction.

`preferredDuringSchedulingIgnoredDuringExecution` (soft affinity) is used
intentionally:
- On clusters **with** `stable-node-pool` (us-dev-2): etcd lands on stable nodes → `WhenEmpty` policy never evicts it
- On clusters **without** `stable-node-pool` (gov-stg-2, all prod clusters): no matching nodes exist → scheduler falls back to any available node — current behavior fully preserved

The toleration for `infoblox.com/do-not-disrupt: NoSchedule` is required to
schedule onto the stable-node-pool (which carries that taint). On clusters where
no node has that taint, the toleration is harmless.

**Chart version:** `0.1.0 → 0.2.0`

---

### `helm-charts/konk-service/values.yaml` + deployment templates — KonkService CPU and affinity

**CPU request: `10m → 100m`**

Raises the CPU request for all KonkService pods (`apiservice`, `kubeconfig`,
`apiservice-test`) from `10m` to `100m`. These are lighter workloads than etcd,
but the same Karpenter underutilization trigger applied — confirmed by observed
evictions of KonkService kubeconfig pods on gov-stg-2.

**Same soft stable-node-pool affinity + toleration**

```yaml
tolerations:
  - key: infoblox.com/do-not-disrupt
    operator: Exists
    effect: NoSchedule

affinity:
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 100
        preference:
          matchExpressions:
            - key: node-group-type
              operator: In
              values:
                - stable
```

Added to `values.yaml` and wired into all three deployment templates
(`apiservice-deployment.yaml`, `kubeconfig-deployment.yaml`,
`apiservice-test-deployment.yaml`) via `{{- with .Values.tolerations }}` /
`{{- with .Values.affinity }}` blocks. Identical fallback behavior to etcd:
soft preference on clusters with stable-node-pool, no change on clusters without.

**Chart version:** `0.1.0 → 0.2.0`

---

### `helm-charts/etcd/templates/poddisruptionbudget.yaml` — New file

```yaml
{{- if and .Values.pdb.enabled (gt (int .Values.replicaCount) 1) }}
apiVersion: policy/v1
kind: PodDisruptionBudget
...
spec:
  minAvailable: {{ .Values.pdb.minAvailable }}   # default: 2
  selector:
    matchLabels: <etcd selectorLabels>
{{- end }}
```

Adds a PDB as a defense-in-depth layer on etcd. Even on clusters where the CPU
fix or stable-node-pool prevents Karpenter from evicting, the PDB enforces the
same protection at the Kubernetes API level — respected by Karpenter,
`kubectl drain`, and any other eviction actor.

`minAvailable: 2` on a 3-replica cluster gives `disruptionsAllowed: 1`:

| PDB setting | Replicas | disruptionsAllowed | Effect |
|-------------|----------|--------------------|--------|
| `minAvailable: 3` | 3 | **0** | Blocks Karpenter AND node drains — same as dapr bug PTOCP-5191 |
| **`minAvailable: 2`** | **3** | **1** | Quorum safe, 1 eviction at a time, upgrades work ✅ |
| `minAvailable: 1` | 3 | 2 | Allows 2 simultaneous evictions — quorum unsafe |

The template guard `replicaCount > 1` ensures single-replica dev deployments do
not get a PDB that would block all disruptions.

> **How the PDB reaches the cluster via the operator:**
> The Etcd CR spec (from the konk chart's `.Values.etcd`) does not set `pdb.*`.
> So when the operator renders the etcd chart, `pdb.enabled: true` from the etcd
> chart's own defaults applies — it is not overridden. The PDB is created without
> any additional konk chart changes needed.

---

### `helm-charts/etcd/values.yaml` — PDB defaults + CPU default for standalone use

```yaml
resources:
  requests:
    cpu: 200m    # was 100m — aligns with konk chart, correct for standalone deployments

pdb:
  enabled: true
  minAvailable: 2
```

The CPU change here (`100m → 200m`) does not affect operator-managed deployments
(the konk chart's `10m → 200m` fix is what matters there). It aligns the etcd
chart's standalone default with the operator-managed value and makes the chart
self-consistent for any direct use.

**Chart version:** `1.1.0 → 1.2.0`

---

## How all layers interact across cluster types

```
Cluster without stable-node-pool (gov-stg-2, prd-1, etc.)
  etcd CPU: 200m / KonkService CPU: 100m → nodes not flagged Underutilized
  Affinity: preferred but not satisfied → scheduler uses any node (no change)
  PDB: minAvailable=2 → at most 1 etcd eviction at a time if triggered

Cluster with stable-node-pool (us-dev-2)
  CPU fixes also apply here as a baseline
  Affinity: preferred + toleration → etcd and KonkService pods land on stable-node-pool
  stable-node-pool: WhenEmpty policy → Karpenter never evicts pods to consolidate
  PDB: minAvailable=2 → enforced at K8s API level regardless
```

---

## Test plan

- [ ] us-dev-2: `kubectl get pods -n aggregate -o wide` shows `bulk-konk-etcd-*` and KonkService pods on `stable-node-pool` nodes
- [ ] us-dev-2: `kubectl get pdb -n aggregate bulk-konk-etcd` shows `ALLOWED DISRUPTIONS: 1`
- [ ] gov-stg-2: etcd and KonkService pods schedule on regular nodes (no stable-node-pool present)
- [ ] gov-stg-2: `kubectl get statefulset bulk-konk-etcd -n aggregate -o jsonpath='{.spec.template.spec.containers[0].resources.requests}'` shows `cpu: 200m, memory: 128Mi`
- [ ] gov-stg-2: KonkService deployment pods show `cpu: 100m` in their resource requests
- [ ] `helm template helm-charts/etcd --set replicaCount=1` does NOT render a PDB
- [ ] `helm template helm-charts/etcd --set replicaCount=3` renders a PDB with `minAvailable: 2`
- [ ] No etcd or KonkService pod evictions observed for 2× the `consolidateAfter` window post-deploy on both clusters

Ref: DEVOPS-47739

🤖 Generated with [Claude Code](https://claude.com/claude-code)