### PR TITLE
fix(etcd): prevent Karpenter eviction loops (release/upgrade-etcd)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,7 +91,7 @@ jobs:
           make deploy-cert-manager deploy-ingress-nginx INGRESS_VERSION=${{ matrix.ingressVersion || env.ingress_version }}
       - name: Install konk-operator
         if: ${{ matrix.isUpgrade }}
-        timeout-minutes: 6
+        timeout-minutes: 12
         run: |
           make kind-load-konk KIND_NAME="chart-testing"
           make deploy-konk-operator

--- a/helm-charts/etcd/Chart.yaml
+++ b/helm-charts/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: etcd
 description: A custom etcd Helm chart using upstream etcd images
-version: 1.1.2
+version: 1.2.2
 appVersion: "3.7.1"
 type: application
 

--- a/helm-charts/etcd/templates/poddisruptionbudget.yaml
+++ b/helm-charts/etcd/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.pdb.enabled (gt (int .Values.statefulset.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "etcd.helmAnnotations" . | nindent 4 }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "etcd.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm-charts/etcd/values.yaml
+++ b/helm-charts/etcd/values.yaml
@@ -152,10 +152,27 @@ startupProbe:
   failureThreshold: 60
   successThreshold: 1
 
+## @section PodDisruptionBudget parameters
+pdb:
+  enabled: true
+  minAvailable: 2
+
 ## @section Scheduling parameters
 nodeSelector: {}
-tolerations: []
-affinity: {}
+tolerations:
+  - key: infoblox.com/do-not-disrupt
+    operator: Exists
+    effect: NoSchedule
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: node-group-type
+              operator: In
+              values:
+                - stable
 priorityClassName: ""
 
 ## @section Cluster parameters

--- a/helm-charts/konk-service/Chart.yaml
+++ b/helm-charts/konk-service/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.25.8
 description: Registers an aggregate API service in Konk
 name: konk-service
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/helm-charts/konk-service/README.md
+++ b/helm-charts/konk-service/README.md
@@ -1,6 +1,6 @@
 # konk-service
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
 
 Registers an aggregate API service in Konk
 
@@ -12,6 +12,10 @@ When deploying with `helm install`, these configurations are values and can be o
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key | string | `"node-group-type"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator | string | `"In"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0] | string | `"stable"` |  |
+| affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | annotations | object | `{}` | annotations to add to the APIService created in Konk by KonkService |
 | crds | string | `nil` |  |
 | fullnameOverride | string | `""` |  |
@@ -28,7 +32,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | kind.image.repository | string | `"kindest/node"` |  |
 | kind.image.tag | string | `"v1.25.8"` | Overrides the image tag whose default is the chart appVersion. |
 | kind.resources.limits.memory | string | `"4Gi"` |  |
-| kind.resources.requests.cpu | string | `"10m"` |  |
+| kind.resources.requests.cpu | string | `"100m"` |  |
 | kind.resources.requests.memory | string | `"40Mi"` |  |
 | kind.securityContext | object | `{}` |  |
 | konk.name | string | `""` | should be set to the konk-name |
@@ -41,4 +45,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | space.enabled | bool | `false` |  |
+| tolerations[0].effect | string | `"NoSchedule"` |  |
+| tolerations[0].key | string | `"infoblox.com/do-not-disrupt"` |  |
+| tolerations[0].operator | string | `"Exists"` |  |
 | version | string | `"v1alpha1"` |  |

--- a/helm-charts/konk-service/templates/apiservice-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-deployment.yaml
@@ -23,6 +23,14 @@ spec:
         app.kubernetes.io/component: apiservice
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kind
         securityContext:

--- a/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
+++ b/helm-charts/konk-service/templates/apiservice-test-deployment.yaml
@@ -23,6 +23,14 @@ spec:
         app.kubernetes.io/component: apiservice-test
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kind
         securityContext:

--- a/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
+++ b/helm-charts/konk-service/templates/kubeconfig-deployment.yaml
@@ -22,6 +22,14 @@ spec:
         app.kubernetes.io/component: kubeconfig
     spec:
       serviceAccountName: {{ include "konk-service.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kind
         securityContext:

--- a/helm-charts/konk-service/values.yaml
+++ b/helm-charts/konk-service/values.yaml
@@ -30,7 +30,7 @@ kind:
     limits:
       memory: 4Gi
     requests:
-      cpu: 10m
+      cpu: 100m
       memory: 40Mi
   securityContext: {}
     # capabilities:
@@ -39,6 +39,22 @@ kind:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+
+tolerations:
+  - key: infoblox.com/do-not-disrupt
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: node-group-type
+              operator: In
+              values:
+                - stable
 
 ingress:
   enabled: false

--- a/helm-charts/konk/Chart.yaml
+++ b/helm-charts/konk/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.25.8
 description: Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 name: konk
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -1,6 +1,6 @@
 # konk
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.25.8](https://img.shields.io/badge/AppVersion-v1.25.8-informational?style=flat-square)
 
 Deploys an instance of konk (kubernetes on kubernetes), typically run by konk-operator
 
@@ -31,6 +31,10 @@ When deploying with `helm install`, these configurations are values and can be o
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | certManager.namespace | string | `nil` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key | string | `"node-group-type"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator | string | `"In"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0] | string | `"stable"` |  |
+| etcd.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | etcd.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | etcd.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | etcd.containerSecurityContext.enabled | bool | `true` |  |
@@ -45,12 +49,15 @@ When deploying with `helm install`, these configurations are values and can be o
 | etcd.persistence.size | string | `"8Gi"` |  |
 | etcd.replicaCount | int | `3` |  |
 | etcd.resources.limits.memory | string | `"4Gi"` |  |
-| etcd.resources.requests.cpu | string | `"10m"` |  |
-| etcd.resources.requests.memory | string | `"64Mi"` |  |
+| etcd.resources.requests.cpu | string | `"200m"` |  |
+| etcd.resources.requests.memory | string | `"128Mi"` |  |
 | etcd.securityContext.enabled | bool | `true` |  |
 | etcd.securityContext.fsGroup | int | `1001` |  |
 | etcd.securityContext.runAsNonRoot | bool | `true` |  |
 | etcd.securityContext.runAsUser | int | `1001` |  |
+| etcd.tolerations[0].effect | string | `"NoSchedule"` |  |
+| etcd.tolerations[0].key | string | `"infoblox.com/do-not-disrupt"` |  |
+| etcd.tolerations[0].operator | string | `"Exists"` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"HTTPS"` |  |

--- a/helm-charts/konk/README.md
+++ b/helm-charts/konk/README.md
@@ -47,7 +47,6 @@ When deploying with `helm install`, these configurations are values and can be o
 | etcd.operator | bool | `true` | defines how Konk's internal etcd is deployed. `true`: etcd is deployed by konk-operator `false`: etcd is deployed as a sidecar of konk's kube-apiserver |
 | etcd.persistence.enabled | bool | `true` |  |
 | etcd.persistence.size | string | `"8Gi"` |  |
-| etcd.replicaCount | int | `3` |  |
 | etcd.resources.limits.memory | string | `"4Gi"` |  |
 | etcd.resources.requests.cpu | string | `"200m"` |  |
 | etcd.resources.requests.memory | string | `"128Mi"` |  |
@@ -55,6 +54,7 @@ When deploying with `helm install`, these configurations are values and can be o
 | etcd.securityContext.fsGroup | int | `1001` |  |
 | etcd.securityContext.runAsNonRoot | bool | `true` |  |
 | etcd.securityContext.runAsUser | int | `1001` |  |
+| etcd.statefulset.replicaCount | int | `3` |  |
 | etcd.tolerations[0].effect | string | `"NoSchedule"` |  |
 | etcd.tolerations[0].key | string | `"infoblox.com/do-not-disrupt"` |  |
 | etcd.tolerations[0].operator | string | `"Exists"` |  |

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -100,10 +100,11 @@ etcd:
   # `true`: etcd is deployed by konk-operator
   # `false`: etcd is deployed as a sidecar of konk's kube-apiserver
   operator: true
-  
-  # Number of etcd replicas
-  replicaCount: 3
-  
+
+  statefulset:
+    # Number of etcd replicas
+    replicaCount: 3
+
   # Persistence settings
   persistence:
     enabled: true

--- a/helm-charts/konk/values.yaml
+++ b/helm-charts/konk/values.yaml
@@ -66,8 +66,22 @@ etcd:
     limits:
       memory: 4Gi
     requests:
-      cpu: 10m
-      memory: 64Mi
+      cpu: 200m
+      memory: 128Mi
+  tolerations:
+    - key: infoblox.com/do-not-disrupt
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-group-type
+                operator: In
+                values:
+                  - stable
   securityContext:
     enabled: true
     fsGroup: 1001


### PR DESCRIPTION
## Summary

Port of [PR #682](https://github.com/infobloxopen/konk/pull/682) to the `release/upgrade-etcd` branch.

Fixes the etcd Karpenter consolidation eviction loop on us-dev-2 (DEVOPS-47739). The `WhenEmptyOrUnderutilized` Karpenter consolidation policy was evicting nodes hosting etcd pods because their CPU requests (10m) were far below actual usage, making nodes appear underutilized. Each eviction triggered a 1–2 min EBS volume detach/reattach cycle, cascading into API downtime for all konk-served services.

Re-implemented from scratch (not cherry-picked) due to structural differences between `main` and `release/upgrade-etcd`.

---

## Changes

### `helm-charts/etcd` (1.1.2 → 1.2.2)

**`values.yaml`**
- Added `pdb` section (`enabled: true`, `minAvailable: 2`)
- Populated `tolerations` with `infoblox.com/do-not-disrupt: NoSchedule` toleration (harmless on clusters without the taint)
- Populated `affinity` with soft (`preferredDuringSchedulingIgnoredDuringExecution`) node affinity for `node-group-type: stable` — falls back to any node on clusters without `stable-node-pool`

**`templates/poddisruptionbudget.yaml`** _(new)_
- Creates a `PodDisruptionBudget` when `pdb.enabled=true` and `statefulset.replicaCount > 1`
- `minAvailable: 2` on a 3-replica cluster → `disruptionsAllowed: 1`, preventing simultaneous eviction of multiple etcd members while still allowing rolling node drains
- Guard on `replicaCount > 1` prevents single-replica dev deployments from getting a PDB that blocks all eviction

### `helm-charts/konk` (0.1.0 → 0.2.0)

**`values.yaml`** — critical fix
- `etcd.resources.requests.cpu`: `10m → 200m` — **this is the actual source of the 10m**; the konk operator passes `.Values.etcd` as helm values into the Etcd CR, overriding etcd chart defaults
- `etcd.resources.requests.memory`: `64Mi → 128Mi` — aligns with actual etcd memory footprint
- Added `etcd.tolerations` — tolerate `infoblox.com/do-not-disrupt: NoSchedule` taint on stable-node-pool nodes
- Added `etcd.affinity` — soft preference for `node-group-type: stable` nodes; no-op on clusters without the pool

### `helm-charts/konk-service` (0.1.0 → 0.2.0)

**`values.yaml`**
- `kind.resources.requests.cpu`: `10m → 100m` — KonkService pods (apiservice, kubeconfig, apiservice-test) also suffered from the same underutilization-triggered eviction
- Added top-level `tolerations` and `affinity` (same stable-node-pool soft preference)

**`templates/apiservice-deployment.yaml`**, **`templates/kubeconfig-deployment.yaml`**, **`templates/apiservice-test-deployment.yaml`**
- Wired `{{- with .Values.tolerations }}` and `{{- with .Values.affinity }}` blocks into pod specs

---

## Why soft affinity, not nodeSelector

Using `preferredDuringSchedulingIgnoredDuringExecution` (soft) instead of a hard `nodeSelector` or `required` affinity rule means:
- Clusters **with** `stable-node-pool` (e.g. us-dev-2): pods prefer stable nodes with `WhenEmpty` consolidation → no eviction
- Clusters **without** `stable-node-pool`: pods schedule normally on any available node — no breakage

The toleration is similarly harmless — clusters without the taint simply ignore it.

## Testing

- us-dev-2 has a `stable-node-pool` NodePool with `consolidationPolicy: WhenEmpty`, taint `infoblox.com/do-not-disrupt: NoSchedule`, and label `node-group-type: stable`
- After this fix, etcd and KonkService pods should land on stable-node-pool nodes and not be evicted by Karpenter consolidation

## Related

- Main branch PR: #682
- Jira: DEVOPS-47739