### PR TITLE
feat(konk-operator): add Operator Start Time and Container Restarts panels

### DIFF
--- a/helm-charts/etcd/dashboards/etcd.json
+++ b/helm-charts/etcd/dashboards/etcd.json
@@ -62,7 +62,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-      "description": "Unix timestamp of when each etcd process started. A step-jump (any pod, leader or follower) means that pod was recreated.",
+      "description": "Wall-clock time of last etcd process start per pod. A step-jump means that pod was recreated.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -107,7 +107,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "process_start_time_seconds{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "expr": "process_start_time_seconds{namespace=\"$namespace\", pod=~\"$pod\"} * 1000",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -237,7 +237,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "increase(etcd_server_leader_changes_seen_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "expr": "ceil(increase(etcd_server_leader_changes_seen_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -247,7 +247,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-      "description": "Failed Raft proposals. Non-zero sustained values indicate write failures during a restart window.",
+      "description": "Failed Raft proposals (new failures in window) and pending proposals (current gauge). Non-zero sustained failed values indicate write failures during a restart window.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -292,7 +292,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "etcd_server_proposals_failed_total{namespace=\"$namespace\", pod=~\"$pod\"}",
+          "expr": "increase(etcd_server_proposals_failed_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
           "legendFormat": "{{pod}} failed",
           "refId": "A"
         },

--- a/helm-charts/etcd/dashboards/etcd.json
+++ b/helm-charts/etcd/dashboards/etcd.json
@@ -167,13 +167,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "sum(kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"true\"})",
+          "expr": "sum(max by (pod, namespace) (kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"true\"}))",
           "legendFormat": "ready",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "sum(kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"false\"})",
+          "expr": "sum(max by (pod, namespace) (kube_pod_status_ready{namespace=\"$namespace\", pod=~\"$pod\", condition=\"false\"}))",
           "legendFormat": "not ready",
           "refId": "B"
         }

--- a/helm-charts/konk-operator/dashboards/konk-operator.json
+++ b/helm-charts/konk-operator/dashboards/konk-operator.json
@@ -273,6 +273,192 @@
       }
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS_UID}"
+      },
+      "description": "Step-jump on any line = that pod was restarted or recreated (eviction, rollout, OOMKill). Catches both leader and follower restarts unlike restart counters which reset on eviction.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS_UID}"
+          },
+          "expr": "process_start_time_seconds{namespace=\"konk\", pod=~\"konk-operator-.*\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Operator Start Time",
+      "type": "timeseries",
+      "pluginVersion": "10.4.19",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "dateTimeAsLocal",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS_UID}"
+      },
+      "description": "Counts OOMKill and crash-loop restarts within the same pod. Eviction-based recreates show as 0 here because a new pod starts with RESTARTS=0 — use Operator Start Time to catch those.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS_UID}"
+          },
+          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"konk\", pod=~\"konk-operator-.*\"}[$__rate_interval])",
+          "legendFormat": "{{pod}} / {{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container Restarts",
+      "type": "timeseries",
+      "pluginVersion": "10.4.19",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -282,7 +468,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 19
       },
       "id": 10,
       "panels": [],
@@ -308,7 +494,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 11
+        "y": 20
       },
       "id": 8,
       "targets": [


### PR DESCRIPTION
## Summary

- **Problem**: The konk-operator dashboard had no visibility into pod restarts or recreations. `kube_pod_container_status_restarts_total` alone misses eviction-based recreates — a new pod starts with `RESTARTS=0` so the counter resets and the event is invisible. (Observed today: Karpenter evicted the operator pod for node underutilization with no visible signal in the dashboard.)
- **Fix**: Two new panels in the `konk-operator` row.

## Panels added

| Panel | Metric | What it catches |
|---|---|---|
| **Operator Start Time** | `process_start_time_seconds{namespace="konk", pod=~"konk-operator-.*"}` | Any restart or pod recreate — step-jump = pod replaced, regardless of cause (eviction, rollout, OOMKill) |
| **Container Restarts** | `increase(kube_pod_container_status_restarts_total{namespace="konk", pod=~"konk-operator-.*"}[$__rate_interval])` | OOMKill and crash-loop restarts specifically; threshold turns red at ≥1 |

Using both together distinguishes:
- Step-jump in start time + zero restart rate → eviction or rollout
- Step-jump + non-zero restart rate → OOMKill or crash

## Test plan

- [ ] Deploy konk-operator with metrics enabled; confirm both panels populate
- [ ] Trigger a `kubectl rollout restart` — verify **Operator Start Time** shows a step-jump, **Container Restarts** stays at 0
- [ ] Confirm no regression with existing panels (konk count, kube api client requests, konks ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)