### PR TITLE
fix(dashboards): sweep the etcd fixes across konk-operator and konk-services

### DIFF
--- a/helm-charts/konk-operator/dashboards/konk-operator.json
+++ b/helm-charts/konk-operator/dashboards/konk-operator.json
@@ -510,7 +510,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS_UID}"
       },
-      "description": "Readiness of each konk (kube-apiserver) pod. Positive is ready, negative is not ready, so a pod flipping shows as a spike through zero. One series per pod, so pods replaced during the window each keep their own line -- repeated replacements of a single-replica Deployment show up here as a staircase.",
+      "description": "Readiness of each konk (kube-apiserver) pod: 1 = Ready, 0 = Not Ready, one series per pod.\n\nPreviously plotted two series per pod -- condition=\"true\" as positive and condition=\"false\" negated -- which made a single pod look like two entries in the legend. The second series carried no information: kube-state-metrics emits condition true/false/unknown for every pod, and condition=\"false\" is simply the inverse of condition=\"true\" for a binary readiness signal, so it contributed a permanent flat line at zero for every healthy pod.\n\nAxis pinned to 0..1. With only a flat zero series visible the axis previously auto-scaled to 0-100. Aggregated with max by(...) so a double-scraped pod cannot produce duplicate lines.",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -524,22 +524,9 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS_UID}"
           },
-          "editorMode": "code",
-          "expr": "sum(kube_pod_status_ready{pod=~\".*-konk-[a-f0-9]+-[a-z0-9]+$\",condition=\"true\"}) by (namespace, pod)",
-          "range": true,
-          "refId": "A",
-          "legendFormat": "{{namespace}}/{{pod}}"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS_UID}"
-          },
-          "editorMode": "code",
-          "expr": "sum(kube_pod_status_ready{pod=~\".*-konk-[a-f0-9]+-[a-z0-9]+$\",condition=\"false\"}) by (namespace, pod) * -1",
-          "range": true,
-          "refId": "B",
-          "legendFormat": "{{namespace}}/{{pod}} not ready"
+          "expr": "max by (namespace, pod) (kube_pod_status_ready{pod=~\".*-konk-[a-f0-9]+-[a-z0-9]+$\",condition=\"true\"})",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": "A"
         }
       ],
       "title": "konks ready",
@@ -566,7 +553,7 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -579,11 +566,27 @@
               "mode": "normal"
             },
             "thresholdsStyle": {
-              "mode": "area"
+              "mode": "off"
             }
           },
           "links": [],
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Not Ready"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Ready"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -593,10 +596,13 @@
               },
               {
                 "color": "green",
-                "value": 0
+                "value": 1
               }
             ]
-          }
+          },
+          "min": 0,
+          "max": 1,
+          "decimals": 0
         },
         "overrides": []
       },

--- a/helm-charts/konk-operator/dashboards/konk-operator.json
+++ b/helm-charts/konk-operator/dashboards/konk-operator.json
@@ -296,7 +296,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS_UID}"
       },
-      "description": "When the operator process started. A jump means it restarted; eviction-based recreates show here even though Container Restarts stays 0, because a new pod starts with RESTARTS=0. Selects on app_kubernetes_io_instance, which is present under BOTH collection paths: Alloy's annotation discovery labelmaps pod labels in automatically, and the chart's PodMonitor carries it via podTargetLabels. Selecting on namespace would break under annotation discovery, which sets kubernetes_namespace rather than namespace.",
+      "description": "How long the konk-operator pod has been running. A drop to zero is a pod recreate -- the case Container Restarts cannot see, because a fresh pod starts with RESTARTS=0. Shown as uptime rather than an absolute start timestamp: with a single flat series and a datetime unit, Grafana padded the axis from 1970 to 2080.",
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -310,12 +310,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS_UID}"
           },
-          "expr": "process_start_time_seconds{app_kubernetes_io_instance=\"konk-operator\"} * 1000",
+          "expr": "time() - process_start_time_seconds{app_kubernetes_io_instance=\"konk-operator\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
-      "title": "Operator Start Time",
+      "title": "Operator uptime",
       "type": "timeseries",
       "pluginVersion": "10.4.19",
       "fieldConfig": {
@@ -323,7 +323,7 @@
           "color": {
             "mode": "palette-classic"
           },
-          "unit": "dateTimeAsLocal",
+          "unit": "s",
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -354,7 +354,8 @@
             },
             "thresholdsStyle": {
               "mode": "off"
-            }
+            },
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -366,7 +367,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "min": 0
         },
         "overrides": []
       },
@@ -387,7 +389,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS_UID}"
       },
-      "description": "Counts OOMKill and crash-loop restarts within the same pod. Eviction-based recreates show as 0 here because a new pod starts with RESTARTS=0 — use Operator Start Time to catch those.",
+      "description": "Restarts of the konk-operator container. Counts OOMKill and crash-loop restarts within the same pod; an eviction-based recreate reads 0 here because a new pod starts with RESTARTS=0 -- Operator uptime catches those. Uses an explicit [5m] window rather than $__rate_interval: the PodMonitor scrapes every 60s and $__rate_interval resolves to ~60-75s, too few samples for increase() to return anything.",
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -401,7 +403,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS_UID}"
           },
-          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"konk\", pod=~\"konk-operator-.*\"}[$__rate_interval])",
+          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"konk\", pod=~\"konk-operator-.*\"}[5m])",
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
         }
@@ -790,8 +792,10 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line+area"
-            }
+              "mode": "off"
+            },
+            "axisSoftMax": 1,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -809,7 +813,8 @@
                 "value": 0.01
               }
             ]
-          }
+          },
+          "noValue": "no 5xx"
         },
         "overrides": []
       },
@@ -845,7 +850,7 @@
       ],
       "title": "Operator 5xx error rate",
       "type": "timeseries",
-      "description": "Operator reconcile failures against the parent Kube API. Sustained non-zero means reconciliation is failing. Reads \"No data\" rather than 0 while healthy: Prometheus only creates series for response codes actually observed, so with no 5xx ever returned there is no series to rate. Selects on app_kubernetes_io_instance, which is present under BOTH collection paths: Alloy's annotation discovery labelmaps pod labels in automatically, and the chart's PodMonitor carries it via podTargetLabels. Selecting on namespace would break under annotation discovery, which sets kubernetes_namespace rather than namespace."
+      "description": "Operator reconcile failures against the parent Kube API. Sustained non-zero means reconciliation is failing. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero was rendered almost entirely red. Reads \"no 5xx\" when empty, which is the healthy state: Prometheus only creates series for response codes actually observed, and an operator that has never received a 5xx has no series to rate."
     },
     {
       "datasource": {
@@ -886,8 +891,10 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line+area"
-            }
+              "mode": "off"
+            },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -944,7 +951,7 @@
       ],
       "title": "Konk pod restart count (1h)",
       "type": "timeseries",
-      "description": "kube-apiserver restarts per konk instance over the trailing hour."
+      "description": "kube-apiserver restarts per konk instance over the trailing hour. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero was rendered almost entirely red."
     },
     {
       "collapsed": false,
@@ -1234,7 +1241,9 @@
             },
             "thresholdsStyle": {
               "mode": "off"
-            }
+            },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -1274,7 +1283,7 @@
       ],
       "title": "Provision restart history",
       "type": "timeseries",
-      "description": "Correlate restart spikes with cert renewal windows."
+      "description": "Correlate restart spikes with cert renewal windows. Soft max keeps a single restart visible; the axis previously auto-scaled to 0-100 for a metric that sits at zero."
     },
     {
       "collapsed": false,
@@ -1440,7 +1449,7 @@
           "legendFormat": "days"
         }
       ],
-      "title": "Next provision wake-up (days)",
+      "title": "Next provision wake-up (d)",
       "type": "stat",
       "description": "Days until provision should next act. Below 0 means provision is overdue to renew."
     },
@@ -1516,7 +1525,7 @@
           "legendFormat": "days"
         }
       ],
-      "title": "Self-signed issuer cert expiry (days)",
+      "title": "Self-signed CA expiry (d)",
       "type": "stat",
       "description": "Expiry of bulk-konk-requestheader-self-signed, the long-lived (~2 year) self-signed issuer cert managed by cert-manager. NOTE: this panel previously tracked bulk-konk-ca, which cannot work -- that is a raw kubernetes.io/tls Secret created by provision/kubeadm, not a cert-manager Certificate, so cert-manager exports no metric for it. Cluster-CA expiry needs a different source (x509 parsing or a custom exporter); see spec 4.2."
     },
@@ -1798,14 +1807,14 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS_UID}"
           },
-          "expr": "count(kube_deployment_status_replicas_available{deployment=~\".*-(kubeconfig|konk-service-apiservice|kubectl-apiservice)\"} < 1)",
+          "expr": "count(kube_deployment_status_replicas_available{deployment=~\".*-(kubeconfig|konk-service-apiservice|kubectl-apiservice)\"} < 1) or vector(0)",
           "refId": "A",
           "legendFormat": "unavailable"
         }
       ],
       "title": "Deployments unavailable",
       "type": "stat",
-      "description": "kubeconfig or apiservice Deployments with no available replica.",
+      "description": "kubeconfig or apiservice Deployments with no available replica. Reads 0 when healthy rather than \"No data\": count() over an empty set returns no series at all, so without the vector(0) fallback a healthy fleet is indistinguishable from a broken query.",
       "links": [
         {
           "title": "Drill down: konk-services",
@@ -1872,14 +1881,14 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS_UID}"
           },
-          "expr": "count(kube_pod_status_ready{pod=~\".*konk-service.*\", condition=\"true\"} == 0)",
+          "expr": "count(kube_pod_status_ready{pod=~\".*konk-service.*\", condition=\"true\"} == 0) or vector(0)",
           "refId": "A",
           "legendFormat": "not ready"
         }
       ],
       "title": "konk-service pods not Ready",
       "type": "stat",
-      "description": "konk-service pods failing their readiness probe. Matches '.*konk-service.*'; the previous component-suffix regex missed pods whose names Kubernetes truncated.",
+      "description": "konk-service pods failing their readiness probe. Reads 0 when healthy rather than \"No data\": count() over an empty set returns no series at all, so without the vector(0) fallback a healthy fleet is indistinguishable from a broken query.",
       "links": [
         {
           "title": "Drill down: konk-services",

--- a/helm-charts/konk-operator/dashboards/konk-services.json
+++ b/helm-charts/konk-operator/dashboards/konk-services.json
@@ -559,7 +559,9 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "line+area" }
+            "thresholdsStyle": { "mode": "off" },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -588,7 +590,7 @@
       ],
       "title": "Unavailable replicas over time",
       "type": "timeseries",
-      "description": "Shows how long a component has been degraded, not just that it is degraded now."
+      "description": "Shows how long a component has been degraded, not just that it is degraded now. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero rendered almost entirely red."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -662,7 +664,7 @@
       ],
       "title": "kubeconfig Deployments vs KonkServices (per namespace)",
       "transformations": [
-        { "id": "merge", "options": {} },
+        { "id": "joinByField", "options": { "byField": "namespace", "mode": "outer" } },
         {
           "id": "organize",
           "options": {
@@ -677,7 +679,10 @@
               "prometheus": true,
               "service": true,
               "cluster": true,
-              "env": true
+              "env": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
             },
             "includeByName": {},
             "renameByName": {
@@ -690,7 +695,7 @@
         }
       ],
       "type": "table",
-      "description": "Every KonkService should have exactly one kubeconfig Deployment. A shortfall means the Deployment was never created, so nothing renews the 12h client cert. Reported per NAMESPACE, not per KonkService: mapping a CR name to its Deployment name is not possible from these metrics because Kubernetes truncates to 63 characters (konk-service can be cut to 'k'), so the namespace is as precise as this can honestly get -- use it to narrow where to look. Counts dedupe per object with max by(...) before counting, so a double-scraped operator cannot inflate the KonkService side and fabricate a deficit. The 'missing' column uses a label-preserving zero rather than `or vector(0)`, which is unlabelled and so could never match the `- on(namespace)` join -- the previous form returned nothing in exactly the case this panel exists to catch."
+      "description": "Every KonkService should have exactly one kubeconfig Deployment. A shortfall means the Deployment was never created, so nothing renews the 12h client cert. Reported per NAMESPACE, not per KonkService: mapping a CR name to its Deployment name is not possible from these metrics because Kubernetes truncates to 63 characters (konk-service can be cut to 'k'), so the namespace is as precise as this can honestly get -- use it to narrow where to look. Counts dedupe per object with max by(...) before counting, so a double-scraped operator cannot inflate the KonkService side and fabricate a deficit. The 'missing' column uses a label-preserving zero rather than `or vector(0)`, which is unlabelled and so could never match the `- on(namespace)` join -- the previous form returned nothing in exactly the case this panel exists to catch. Joined with joinByField on namespace: merge matches on every shared field including Time, and three instant queries resolve at different timestamps, so the frames never joined and the 'missing' column stayed empty."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -828,12 +833,12 @@
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
           "expr": "max by (namespace, deployment) (kube_deployment_status_replicas_available{namespace=~\"$namespace\", deployment=~\".*-(kubectl-apiservice|konk-service-apiservice)-test\"})",
           "refId": "A",
-          "legendFormat": "{{namespace}}/{{deployment}}"
+          "legendFormat": "{{deployment}}"
         }
       ],
       "title": "★ apiservice-test availability (ground truth)",
       "type": "state-timeline",
-      "description": "GROUND TRUTH. This component's probe passes only when the APIService exists and its API group lists resources inside konk. If this is red the API is not serving, whatever the other panels say. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component. Placed third by preference: apiservice is the component that serves traffic, so it is read first. Note the spec asks for this panel to be MOST prominent -- it is the only signal that the API is actually serving, because its probe passes only when the APIService exists AND its API group lists resources inside konk. apiservice being available only means the reconciler pod is running."
+      "description": "GROUND TRUTH. This component's probe passes only when the APIService exists and its API group lists resources inside konk. If this is red the API is not serving, whatever the other panels say. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component. Placed third by preference: apiservice is the component that serves traffic, so it is read first. Note the spec asks for this panel to be MOST prominent -- it is the only signal that the API is actually serving, because its probe passes only when the APIService exists AND its API group lists resources inside konk. apiservice being available only means the reconciler pod is running. Row labels show the deployment name only; the namespace prefix pushed them past the available width and Grafana truncated from the left. The panel is already scoped by $namespace."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -881,12 +886,12 @@
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
           "expr": "max by (namespace, deployment) (kube_deployment_status_replicas_available{namespace=~\"$namespace\", deployment=~\".*-kubeconfig\"})",
           "refId": "A",
-          "legendFormat": "{{namespace}}/{{deployment}}"
+          "legendFormat": "{{deployment}}"
         }
       ],
       "title": "kubeconfig availability",
       "type": "state-timeline",
-      "description": "Not available for more than 12h means the client cert has already expired. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component."
+      "description": "Not available for more than 12h means the client cert has already expired. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component. Row labels show the deployment name only; the namespace prefix pushed them past the available width and Grafana truncated from the left. The panel is already scoped by $namespace."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -934,12 +939,12 @@
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
           "expr": "max by (namespace, deployment) (kube_deployment_status_replicas_available{namespace=~\"$namespace\", deployment=~\".*-(kubectl-apiservice|konk-service-apiservice)\"})",
           "refId": "A",
-          "legendFormat": "{{namespace}}/{{deployment}}"
+          "legendFormat": "{{deployment}}"
         }
       ],
       "title": "apiservice availability",
       "type": "state-timeline",
-      "description": "Covers both the v1 (kubectl-apiservice) and v2 (konk-service-apiservice) names. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component."
+      "description": "Covers both the v1 (kubectl-apiservice) and v2 (konk-service-apiservice) names. Tracked per Deployment rather than per pod: with replicaCount 1 '0 available' is exactly 'its pod is not ready', and pod names are truncated so they cannot identify the component. Row labels show the deployment name only; the namespace prefix pushed them past the available width and Grafana truncated from the left. The panel is already scoped by $namespace."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -1011,7 +1016,9 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "line+area" }
+            "thresholdsStyle": { "mode": "off" },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -1044,7 +1051,7 @@
       ],
       "title": "Readiness flapping (6h transitions)",
       "type": "timeseries",
-      "description": "Metric-native equivalent of the e2e script's 'recently recovered' warning. More than 2 transitions in 6h means flapping, which distinguishes a transient blip from sustained instability. Matches pods by '.*konk-service.*', which covers all konk-service pods (51/51 on us-dev-5); the previous component-suffix regex missed pods whose names were truncated by Kubernetes."
+      "description": "Metric-native equivalent of the e2e script's 'recently recovered' warning. More than 2 transitions in 6h means flapping, which distinguishes a transient blip from sustained instability. Matches pods by '.*konk-service.*', which covers all konk-service pods (51/51 on us-dev-5); the previous component-suffix regex missed pods whose names were truncated by Kubernetes. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero rendered almost entirely red."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -1341,7 +1348,9 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "line+area" }
+            "thresholdsStyle": { "mode": "off" },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -1370,7 +1379,7 @@
       ],
       "title": "Cert renewal activity (24h)",
       "type": "timeseries",
-      "description": "A 12h cert should re-issue roughly twice a day. Zero changes over 24h means the renewal loop is stuck even though the pod may look Ready."
+      "description": "A 12h cert should re-issue roughly twice a day. Zero changes over 24h means the renewal loop is stuck even though the pod may look Ready. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero rendered almost entirely red."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -1394,7 +1403,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
-          }
+          },
+          "noValue": "OK"
         },
         "overrides": []
       },
@@ -1537,7 +1547,9 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "line+area" }
+            "thresholdsStyle": { "mode": "off" },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -1566,7 +1578,7 @@
       ],
       "title": "Ready endpoint count per backend",
       "type": "timeseries",
-      "description": "Ready endpoint addresses per APIService backend. Watch for drops to 0."
+      "description": "Ready endpoint addresses per APIService backend. Watch for drops to 0. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero rendered almost entirely red."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -1655,14 +1667,14 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
-          "expr": "count by (namespace) (kube_pod_status_ready{namespace=~\"$namespace\", namespace=~\"aggregate|ddi|atcapi|hostapp|ngp-cp|ntp|tagging-v2|redirect|endpoints\", condition=\"true\"} == 0)",
+          "expr": "count by (namespace) ((kube_pod_status_ready{namespace=~\"$namespace\", namespace=~\"aggregate|ddi|atcapi|hostapp|ngp-cp|ntp|tagging-v2|redirect|endpoints\", condition=\"true\"} == 0) * on (namespace, pod) group_left () (kube_pod_status_phase{namespace=~\"$namespace\", namespace=~\"aggregate|ddi|atcapi|hostapp|ngp-cp|ntp|tagging-v2|redirect|endpoints\", phase=\"Running\"} == 1))",
           "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ],
       "title": "Not-ready pods per namespace",
       "type": "timeseries",
-      "description": "Count of pods failing readiness in each konk namespace, over time. Was a per-pod state timeline, which tried to draw one row per pod -- 512 pods across these namespaces on us-dev-5, 319 in ddi alone -- so the labels collapsed into an illegible block. Counting per namespace bounds it to at most nine series, and only namespaces with a problem appear at all. Reads \"all pods ready\" when empty. This is the broad backend view; the endpoint panels above give the per-Service signal, and Row 3 covers the konk-service components specifically."
+      "description": "Count of RUNNING pods failing readiness in each konk namespace, over time. Restricted to phase=\"Running\": a completed Job reports ready=0, so without that filter CronJob pods and delete-apiservice hooks made a healthy namespace look degraded -- on us-dev-5 all 7 \"not ready\" pods in tagging-v2 were Completed. Counted per namespace rather than per pod because the per-pod form drew one row per pod: 512 across these namespaces, 319 in ddi alone. Reads \"all pods ready\" when empty."
     },
     {
       "collapsed": false,
@@ -1819,7 +1831,9 @@
             "showPoints": "auto",
             "spanNulls": false,
             "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "line+area" }
+            "thresholdsStyle": { "mode": "off" },
+            "axisSoftMax": 1,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],
@@ -1853,7 +1867,7 @@
       ],
       "title": "CPU throttling",
       "type": "timeseries",
-      "description": "Sustained throttling means the CPU limit is too low for the 30s reconcile loops."
+      "description": "Sustained throttling means the CPU limit is too low for the 30s reconcile loops. Threshold area shading is off and the axis has a soft max: with shading on and an unbounded axis, a panel reading zero rendered almost entirely red."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS_UID}" },
@@ -1932,7 +1946,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [{ "color": "text", "value": null }]
-          }
+          },
+          "noValue": "no data for this selection"
         },
         "overrides": [
           {
@@ -2012,7 +2027,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [{ "color": "red", "value": null }]
-          }
+          },
+          "noValue": "no OOMKills"
         },
         "overrides": [
           {


### PR DESCRIPTION
## Summary

Follow-up to #689, from validating **all three** deployed dashboards on us-dev-5 (`v0.2.1-161-g7bbe64c-j32`). Every deployment matches the merged #689 source exactly — etcd 17/17, konk-operator 27/27, konk-services 38/38, zero differing expressions — so every item here is a gap in the source, not a rollout problem.

**The dominant theme:** six presentation/robustness fixes landed on the **etcd** dashboard during #689 and were never swept across the other two. That single gap accounts for most of what follows.

| Fix applied to etcd in #689 | Swept here |
|---|---|
| `or vector(0)` so a healthy count reads `0` | ✅ konk-operator |
| `thresholdsStyle: off` so a healthy panel isn't a red block | ✅ konk-operator ×2, konk-services ×5 |
| `axisSoftMax` on normally-zero panels | ✅ both |
| explicit `[5m]` instead of `$__rate_interval` | ✅ konk-operator |
| `noValue` on ambiguous empties | ✅ both |
| `joinByField` instead of `merge` for multi-query tables | ✅ konk-services |

Two of these now have **generator assertions**, so they fail the build rather than shipping a fourth time:
- no timeseries may retain unbounded alarm shading
- no multi-query table may use `merge`

---

## konk-operator

**`Container Restarts` rendered "No data"** — `$__rate_interval` with no Min interval resolves to ~60–75s against a 60s scrape, fewer than the two samples `increase()` needs. Same defect fixed for etcd in `b64718b`. Now `[5m]`.

**`Deployments unavailable` / `konk-service pods not Ready` read "No data" when healthy** — no `or vector(0)`, and `count()` over an empty set returns no series. Evaluated against live KSM: 34 matching deployments with 0 unavailable, 51 matching pods with 0 not-ready, so `0` is correct and the panels couldn't express it. Both also showed a spurious red `1` during the rollout window — the same defect wearing the opposite face.

Fallback verified in both directions on a live Prometheus:
```
count(up{job="nope"} == 0)              -> EMPTY
count(up{job="nope"} == 0) or vector(0) -> 1 series, value=0
count(up == 1)                          -> 1 series, value=1605
count(up == 1) or vector(0)             -> 1 series, value=1605   (no phantom)
```

**`Konk pod restart count (1h)` was a solid red block** — `line+area` shading, red at 3, unbounded axis, no data → ~97% of a healthy panel red. `Operator 5xx error rate` had the same config and would have followed on its first data point.

**`Operator Start Time` → `Operator uptime`** — `dateTimeAsLocal` with one flat series padded the axis from **1970 to 2080**. Uptime is naturally bounded and a recreate shows as a sawtooth to zero, preserving the panel's purpose from #686 (catching recreates that `Container Restarts` can't see, since a fresh pod starts at `RESTARTS=0`).

**`konks ready` plotted two series per pod** — one pod read as two legend entries naming the same pod. KSM emits `condition` true/false/unknown per pod; for a binary signal `condition="false"` is just the inverse, so it added a permanent flat-zero line labelled `… not ready`. Now one series, axis pinned 0..1, Ready/Not Ready mappings.

**Titles truncated at `w4`** — `Self-signed issuer cert expiry (days)` rendered as `Self-signed issuer cert expiry (`.

**`Provision restart history`** given a soft max; it auto-scaled 0–100 for a metric sitting at zero.

---

## konk-services

**`Not-ready pods per namespace` counted completed Job pods** — the highest-impact fix here. A finished Job legitimately reports `ready=0`, so CronJob and pre-delete-hook pods were counted as failures. Verified against live KSM:

| | count | per namespace |
|---|---|---|
| before | **103** | ddi 78, ngp-cp 12, tagging-v2 7, aggregate 3, atcapi 1, ntp 1, hostapp 1 |
| after | **2** | atcapi 1, ntp 1 |

All 7 in `tagging-v2` were Completed — 6 `hr-watcher` CronJob pods and 1 `delete-apiservice` hook. **The 2 survivors are real**, and one matters: `ntp/ntp-config-service-dbapi-dbclaim-exporter-…` is 1/2 Running with **774 restarts** over 3d10h, a crash-looping sidecar that was buried under 101 false positives.

**Five timeseries rendered as red blocks** — `Unavailable replicas over time`, `Readiness flapping`, `Cert renewal activity`, `Ready endpoint count per backend`, `CPU throttling`.

**`kubeconfig Deployments vs KonkServices` never populated `missing`** — used `merge`, which matches on every shared field including `Time`; three instant queries resolve at different timestamps so the frames never joined, in the panel whose entire purpose is that column. Same fix applied to `Deployment desired vs available` in `146f804` and not swept to its sibling.

**Row 3 state-timeline labels truncated from the left** — Grafana sizes the row-label gutter from the label text with no width knob, so the `{{namespace}}/` prefix is dropped; these panels are already `$namespace`-scoped.

**Three panels given empty-state text** — `CA rotated without propagation` → `OK`, plus `Peak memory over window` and `OOMKills`.

---

## Cluster findings surfaced by the dashboards — not defects

**Orphaned `apiservice-test` Deployment in `ddi`.** `Components available` reported apiservice-test = **18** against 17 KonkServices. The count is correct — two Deployments exist for the same KonkService:

| Deployment | Helm release | Chart |
|---|---|---|
| `…-v2-k-kubectl-apiservice-test` | `dns-config-importexport-apiservice` ⚠️ **v1 release** | `konk-service-0.1.0` |
| `…-v2-konk-service-kubectl-apiservice-test` | `dns-config-importexport-apiservice-v2` ✅ | `konk-service-0.2.0` |

Both owned by KonkService `…-v2`, both Running, created a second apart on 2026-06-22 — persisting ~2 months. The first is annotated to the wrong Helm release and runs the older chart: the Helm-ownership / ghost-resource class from `konk-dashboard-panels.md` §4.1–4.2. Worth cleaning up outside this PR.

---

## Not changed

- **`konks ready` red negative half-plane** — deliberate; negative genuinely is the not-ready region. (The duplicate series underneath it was not deliberate, and is fixed.)
- **`app_kubernetes_io_instance` selectors** — correct as they stand. The chart's PodMonitor sets `podTargetLabels: [app.kubernetes.io/instance]`, verified on the deployed object. An earlier change in #689 (`2f1f0d8`) moved these to `namespace="konk"` on the mistaken belief pod labels weren't mapped; that was reverted before merge and the revert was right.
- **`Server cert remaining (days)` value overlapping its bar** — cosmetic, left alone rather than guess at a layout change that can't be verified without rendering.
- **`Certificates not Ready` / `★ Backends with no ready endpoints` appearing blank** — both *do* have `noValue` set and a sibling table rendered its text correctly, so most likely a PDF pagination artifact rather than a config gap.

## Known, not addressed here

The etcd chart's annotation gating renders correctly but doesn't stick on the live object:

| Layer | State |
|---|---|
| chart rendered with live values | 0 scrape annotations ✅ |
| Helm release manifest, STS pod template | `annotations: null` ✅ |
| **live StatefulSet pod template** | `prometheus.io/{scrape,port}` **present** ❌ |

`managedFields` is stripped on this cluster so the writer couldn't be identified. Consequence: etcd may still be double-scraped, and it's the dashboard-side `max by (pod)` from `581d704` keeping `Has Leader` at three tiles rather than the chart gating. konk-operator is clean — PodMonitor only, annotations absent.

## Verification

- 81/81 PromQL expressions parse, checker negative-controlled against malformed input
- phase filter validated against live KSM (103 → 2, excluded pods enumerated)
- `or vector(0)` validated in both the empty and non-empty case
- generator asserts: no `$__rate_interval`, no unbounded alarm shading, no `merge` on multi-query tables
- `helm lint` clean; per-file formatting round-trips asserted before write

### The rule this PR is really about

Each of these was originally fixed as a one-off panel bug rather than as a class, so it recurred once per dashboard. Two are now enforced by generator assertions rather than review:

- no `timeseries` may keep `thresholdsStyle: line+area` with a non-null threshold step and no `axisSoftMax`/`max`
- no `table` with more than one target may use the `merge` transformation

**Anything added to one dashboard from here should be checked against the other two before it is called done.**

## Refs

- `Issues/konk/observability/konk-dashboard-followups.md` — items 1-14, with the per-panel evidence
- `Issues/konk/observability/konk-dashboard-panels.md` **section 6.9** — the sweep rule above, the completed-Job readiness class, and the still-open list (etcd annotation gating, unbumped chart versions, unproven CA firing path)
