### PR TITLE
fix(konk-operator): bound the Container Restarts axis, name the konk count legend

### DIFF
--- a/helm-charts/konk-operator/dashboards/konk-operator.json
+++ b/helm-charts/konk-operator/dashboards/konk-operator.json
@@ -123,7 +123,8 @@
           },
           "expr": "count(resource_created_at_seconds{group=\"konk.infoblox.com\",kind=\"Konk\"})",
           "instant": false,
-          "refId": "A"
+          "refId": "A",
+          "legendFormat": "Konk CRs"
         }
       ],
       "title": "konk count",
@@ -195,7 +196,8 @@
           "placement": "bottom",
           "showLegend": true
         }
-      }
+      },
+      "description": "Number of Konk CRs in the cluster. Legend is named explicitly; without a legendFormat Grafana printed the raw PromQL expression as the series name."
     },
     {
       "datasource": {
@@ -389,7 +391,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS_UID}"
       },
-      "description": "Restarts of the konk-operator container. Counts OOMKill and crash-loop restarts within the same pod; an eviction-based recreate reads 0 here because a new pod starts with RESTARTS=0 -- Operator uptime catches those. Uses an explicit [5m] window rather than $__rate_interval: the PodMonitor scrapes every 60s and $__rate_interval resolves to ~60-75s, too few samples for increase() to return anything.",
+      "description": "Restarts of the konk-operator container. Counts OOMKill and crash-loop restarts within the same pod; an eviction-based recreate reads 0 here because a new pod starts with RESTARTS=0 -- Operator uptime catches those. Uses an explicit [5m] window rather than $__rate_interval: the datasource sets timeInterval 6s, so $__rate_interval is max($__interval + 6s, 24s) and collapses to 24s at short dashboard ranges -- below the scrape interval, so increase() saw too few samples to return anything. Soft max keeps a single restart visible: the series is present but reads 0 on a healthy operator, and an unbounded axis auto-scaled to 0-100, hiding the line against the x-axis.",
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -446,7 +448,9 @@
             },
             "thresholdsStyle": {
               "mode": "off"
-            }
+            },
+            "axisSoftMax": 5,
+            "axisSoftMin": 0
           },
           "links": [],
           "mappings": [],


### PR DESCRIPTION
## Summary

Two defects on the **deployed** konk-operator dashboard, found after #690 shipped to us-dev-5 as `konk-operator:v0.2.1-162-gbeea16d-j33`.

The live `GrafanaDashboard/konk-operator` diffs clean against the merge commit `beea16d` — 21/21 panels, zero differences in expression, legend, unit, min/max, `noValue`, `axisSoftMax` or shading — so both are gaps in the source, not rollout drift.

**Everything #690 claimed to fix is confirmed fixed.** Items 1–8 all verified in the live panel config *and* the rendered dashboard. Two are worth calling out:

- **`Operator uptime` did more than bound an axis.** It shows a sawtooth dropping at 07:40 local — a genuine pod recreate at 02:10 UTC. That is exactly the event `Container Restarts` cannot see, because a fresh pod starts at `RESTARTS=0`. The panel earned its redesign rather than merely looking tidier.
- **Item 1 is confirmed by data, not by absence of error.** Cortex returns 3 series over 24h (116/5/170 points) for the `[5m]` form where `$__rate_interval` returned none.

---

## 1. `Container Restarts` was invisible, not empty

The `[5m]` fix worked — the series is present, one per pod rollout. But every value is `0`, and with `min: 0`, no `max` and no `axisSoftMax` the axis auto-scaled to **0–100**, pinning a flat zero line to the bottom pixel. Indistinguishable from the "No data" #690 replaced.

This is the same sweep failure #690 was written about, one panel deep. Every sibling in the identical class already had `axisSoftMax` from #689/#690:

| Panel | `axisSoftMax` before this PR |
|---|---|
| `Proposals Failed` (etcd) | 5 ✅ |
| `Konk pod restart count (1h)` | 5 ✅ |
| `Provision restart history` | 5 ✅ |
| `Operator 5xx error rate` | 1 ✅ |
| **`Container Restarts`** | **none** ❌ |

**Fix:** `axisSoftMax: 5`, `axisSoftMin: 0`.

### The assertion is deliberately narrow

The obvious rule is wrong here. Auditing all three dashboards for "`min: 0`, no `max`, no `axisSoftMax`" flags **11** panels, and **10 of them are correct** — latency percentiles, DB size, gRPC traffic, CPU and memory are legitimately unbounded, and a soft max on them would be an arbitrary number.

The class that actually matters is *counters that read zero on a healthy cluster*. Scoped to targets matching `restarts_total|_failed|_errors?_total|oom|code=~"5`, the audit returns exactly one gap — this panel. That scoped form is what's asserted, so it fails the build without flagging 10 correct panels.

## 2. `konk count` printed raw PromQL as its legend

No `legendFormat`, so Grafana fell back to the expression:

```
count(resource_created_at_seconds{group="konk.infoblox.com",kind="Konk"})
```

**Fix:** `legendFormat: "Konk CRs"` plus a description. Asserted for **timeseries** panels only — stat panels legitimately have no series name and row panels carry a vestigial empty target, so the broader form of this assertion fails on correct config.

---

## Correction to the `$__rate_interval` reasoning

The `Container Restarts` tooltip claimed `$__rate_interval` resolves to ~60–75s from a 15s datasource default. That was my assumption, and it was wrong. The datasource is **Cortex with `timeInterval: 6s`**, so:

```
$__rate_interval = max($__interval + 6s, 24s)
                 ≈ 86s at a 24h range
                 = 24s floor at short ranges
```

Starvation is **worse** than described, not better. Conclusion and fix unchanged; tooltip and both docs corrected.

### The dashboards query Cortex, not an in-cluster Prometheus

Recording this because it silently invalidated three earlier verification attempts. `${DS_PROMETHEUS_UID}` resolves to uid `000000001`:

```
url:          http://cortex.services.sdp.infoblox.com/prometheus
header:       X-Scope-OrgID: us-dev-5
timeInterval: 6s
```

`prometheus/prometheus-operated` returns **0 series** for `count(kube_pod_status_ready)`; `federated-prometheus` was the same trap earlier. Cortex is unreachable from a laptop and replies `no org id` without the header. Any future panel verification must query Cortex from an in-cluster pod with that header, or it is measuring nothing.

## Not defects — checked and cleared

**`Operator uptime`'s third legend entry** rendered as a 16-label dump instead of a pod name. Not a dashboard bug — it is the annotation-scrape path disappearing mid-window:

| | old series | current series |
|---|---|---|
| `job` | `kubernetes-pods` (Alloy annotation discovery) | `konk/konk-operator` (PodMonitor) |
| pod identity | `kubernetes_pod_name`, **no `pod` label** | `pod` ✅ |

The unlabelled series covers the first ~14h of the window and stops at the pod recreate; everything after has a proper `pod` label. So `podAnnotations: null` from DC PR [#147190](https://github.com/Infoblox-CTO/deployment-configurations/pull/147190) did what it was meant to, and this also confirms konk-operator *was* previously annotation-scraped — the precondition for the double-scrape. The legend entry ages out of the window on its own.

**`konk count` and `konks ready` appeared to stop before the right edge of the plot.** They don't — over 24h at 300s step they return **288 and 289 points**, full coverage. That was a misread of a rasterised PDF export, and the range query is what settles such questions rather than staring harder at the image.

## Cluster cleanup, outside this PR

Three `dashtest-*` `GrafanaDashboard` objects from the manual test-manifest stage are still on us-dev-5 in the `konk` folder, duplicating the real dashboards:

```
dashtest-etcd-dashtest
dashtest-konk-operator-dashtest
dashtest-konk-operator-konk-services-dashtest
```

Not chart-managed, so nothing will reap them.

## Verification

- live dashboard diffed against `beea16d`: 21/21 panels, 0 differences
- items 1–8 each confirmed in live config and rendered output
- both fixes confirmed by Cortex query, in-cluster with `X-Scope-OrgID`
- `helm lint` clean; formatter round-trip asserted before write
- diff is +8/−4 in one file

Refs: `Issues/konk/observability/konk-dashboard-panels.md` §6.10, `konk-dashboard-followups.md` items 15–16
